### PR TITLE
Add capabilities field to ServerToAgent

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ message ServerToAgent {
     AddonsAvailable addons_available = 5;
     AgentPackageAvailable agent_package_available = 6;
     Flags flags = 7;
+    ServerCapabilities capabilities = 8;
 }
 ```
 


### PR DESCRIPTION
The field description is in the spec but the field is missing in the message.
The field somehow was lost during editing.