### PR TITLE
Add plain HTTP transport to OpAMP

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -188,16 +188,31 @@ deliver to the Agent (such as for example a new remote configuration).
 The default polling interval when the Agent does have anything to deliver is 30
 seconds. This polling interval SHOULD be configurable on the Agent.
 
-When using HTTP transport the sequence messages is exactly the same as it is
-when using the WebSocket transport. The only difference is in the timing in the
-situation when the Server wants to send a message to the Agent but the Server
-needs to wait for the Agent to poll the Server and establish an HTTP request
-over which the Server's message can be sent back.
+When using HTTP transport the sequence of messages is exactly the same as it is
+when using the WebSocket transport. The only difference is in the timing:
+- When the Server wants to send a message to the Agent, the Server needs to wait
+  for the Agent to poll the Server and establish an HTTP request over which the Server's
+  message can be sent back as an HTTP response.
+- When the Agent wants to send a message to the Server and the Agent has previously sent
+  a request to the Server that is not yet responded, the Agent MUST wait until the
+  response is received before a new request can be made. Note that the new request in
+  this case can be made immediately after the previous response is received, the Agent
+  does not need to wait for the polling period between requests.
 
 The Agent MUST set "Content-Type: application/x-protobuf" request header when
 using plain HTTP transport. When the Server receives an HTTP request with this
 header set it SHOULD assume this is a plain HTTP transport request, otherwise it
 SHOULD assume this is a WebSocket transport initiation.
+
+Open Question: do we want to also allow JSON-encoded Protobuf messages? This can
+be fairly trivially achieved by requiring "Content-Type: application/json" header.
+
+The Agent MAY compress the request body using gzip method and MUST specify
+"Content-Encoding: gzip" in that case. Server implementations MUST honour the 
+"Content-Encoding" header and MUST support gzipped or uncompressed request bodies.
+
+The Server MAY compress the response if the Agent indicated it can accept compressed
+response via the "Accept-Encoding" header.
 
 ## AgentToServer Message
 


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opamp-spec/issues/50

Certain applications may not need the OpAMP's capabilities enabled by WebSocket (ability to push configs from server without Agent's polling) and may prefer to implement a simpler HTTP transport. This is likely the case for short-lived Agents such as for example the ones running in AWS lambda. The HTTP transport is likely simpler to implement on the Server (easier to manage connections) and also removes an additional dependency (a WebSocket library) from the client.

We are also considering implementing OpAMP in OpenTelemetry SDKs, which can result in significantly larger number of OpAMP Agents connecting to the Server, so the Server has to handle a larger number of persistent WebSocket connections, which may pose more burden than necessary for use cases where there are no benefits from having a persistent connection (e.g. the above mentioned short-lived use case).

This changes defines a plain HTTP transport for OpAMP. It is a fairly simple modification of the spec to allow it, with AgentToServer/ServerToAgent messages exchanged via HTTP POST Body.

It is also not very complicated to support both WebSocket and plain HTTP on the same Server and if we want to make it seamless from Agent's perspective we can add an indicator of the desired transport in the initial connection attempt made by the Agent, so that the Server knows whether to upgrade to WebSocket or just reply in plain HTTP. The "Content-Type" request header can be such indicator. We can add this in a follow-up PR.

Here is a draft Go OpAMP server implementation for reference: https://github.com/open-telemetry/opamp-go/compare/main...tigrannajaryan:plain-http-transport