### PR TITLE
Fix markdown-toc-check github action

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -1,6 +1,10 @@
 name: Checks
 
-on: [push]
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
 
 jobs:
   markdown-toc-check:


### PR DESCRIPTION
The action is not properly triggered on PRs, e.g. https://github.com/open-telemetry/opamp-spec/pull/77

I am not completely sure why, but I copied the "on" trigger from the https://github.com/open-telemetry/opentelemetry-specification
repo where the action works fine, so hopefully this should fix it.