### PR TITLE
Enclose the TOC in a details element.

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -14,6 +14,9 @@ Note 2: this document requires a simplification pass to reduce the scope, size a
 
 #
 
+<details>
+<summary>Table of Contents</summary>
+
 <!-- toc -->
 
 - [Introduction](#introduction)
@@ -173,6 +176,8 @@ Note 2: this document requires a simplification pass to reduce the scope, size a
   * [Other](#other)
 
 <!-- tocstop -->
+
+</details>
 
 # Introduction
 


### PR DESCRIPTION
It's helpful to have a TOC, but there's a fair amount of scrolling to
do before you get to the text. If we enclose it in a details element,
the reader can show the TOC only when then need it.

Signed-off-by: James Peach <jpeach@cloudflare.com>