### PR TITLE
Use "Alpha" to denote the stability

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -4,7 +4,7 @@ Author: Tigran Najaryan, Splunk
 
 Contributors: Chris Green, Splunk
 
-Status: Early Draft.
+Status: Alpha
 
 Date: September 2021
 


### PR DESCRIPTION
This is consistent with how [we do it for OTLP](https://github.com/open-telemetry/opentelemetry-proto/blob/main/README.md#maturity-level) and how OpenTelemetry [specifies maturity levels](https://github.com/open-telemetry/community/blob/47813530864b9fe5a5146f466a58bd2bb94edc72/maturity-matrix.yaml#L57).