### PR TITLE
Add missing ReportsHealth capability

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -452,6 +452,8 @@ enum AgentCapabilities {
     AcceptsOtherConnectionSettings = 0x00000200;
     // The Agent can accept restart requests.
     AcceptsRestartCommand          = 0x00000400;
+    // The Agent will report Health via AgentToServer.health field.
+    ReportsHealth                  = 0x00000800;
 
     // Add new capabilities here, continuing with the least significant unused bit.
 }


### PR DESCRIPTION
When health reporting was added we forgot to add a corresponding
bit in the AgentCapabilities. This adds the missing bit.