### PR TITLE
Add ReportsRemoteConfig capability

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -454,6 +454,8 @@ enum AgentCapabilities {
     AcceptsRestartCommand          = 0x00000400;
     // The Agent will report Health via AgentToServer.health field.
     ReportsHealth                  = 0x00000800;
+    // The Agent will report RemoteConfig status via AgentToServer.remote_config_status field.
+    ReportsRemoteConfig            = 0x00001000;
 
     // Add new capabilities here, continuing with the least significant unused bit.
 }


### PR DESCRIPTION
Add ReportsRemoteConfig capability

Resolves https://github.com/open-telemetry/opamp-spec/issues/112

All other status fields have a corresponding capability bit except this
one. This results in a non-consistent looking implementation that
has to rely on AcceptsRemoteConfig bit instead to figure out if
RemoteConfigStatus reporting is expected, for example:
https://github.com/open-telemetry/opamp-go/pull/105/files#diff-620a7a2b42e4a4c60a590b0cca50053006e4555c6e70f38dece2f3a6d7ed1338R214

Adding this bit makes the status fields and their corresponding
capabilities bits consistent.