### PR TITLE
Change MAY to SHOULD for Server to Client compression

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -382,7 +382,7 @@ The Client MAY compress the request body using gzip method and MUST specify
 "Content-Encoding: gzip" in that case. Server implementations MUST honour the
 "Content-Encoding" header and MUST support gzipped or uncompressed request bodies.
 
-The Server MAY compress the response if the Client indicated it can accept compressed
+The Server SHOULD compress the response if the Client indicated it can accept compressed
 response via the "Accept-Encoding" header.
 
 ## AgentToServer and ServerToAgent Messages


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opamp-spec/issues/123

We want stronger requirements to use compression.