### PR TITLE
Clarify agent health reporting

### DIFF
--- a/proto/opamp.proto
+++ b/proto/opamp.proto
@@ -555,16 +555,16 @@ enum AgentCapabilities {
 
 // The health of the Agent.
 message AgentHealth {
-    // Set to true if the Agent is up and running.
-    bool up = 1;
+    // Set to true if the Agent is up and healthy.
+    bool healthy = 1;
 
     // Timestamp since the Agent is up, i.e. when the agent was started.
     // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
-    // If "up" is false this field is unused.
+    // If the agent is not running MUST be set to 0.
     fixed64 start_time_unix_nano = 2;
 
-    // Human-readable error message if the Agent is in erroneous state. Typically set
-    // when up==false.
+    // Human-readable error message if the Agent is in erroneous state. SHOULD be set
+    // when healthy==false.
     string last_error = 3;
 }
 

--- a/specification.md
+++ b/specification.md
@@ -47,7 +47,7 @@ Note: this document requires a simplification pass to reduce the scope, size and
       - [AgentDescription.identifying_attributes](#agentdescriptionidentifying_attributes)
       - [AgentDescription.non_identifying_attributes](#agentdescriptionnon_identifying_attributes)
     + [AgentHealth Message](#agenthealth-message)
-      - [AgentHealth.up](#agenthealthup)
+      - [AgentHealth.healthy](#agenthealthhealthy)
       - [AgentHealth.start_time_unix_nano](#agenthealthstart_time_unix_nano)
       - [AgentHealth.last_error](#agenthealthlast_error)
     + [EffectiveConfig Message](#effectiveconfig-message)
@@ -983,26 +983,26 @@ The AgentHealth message has the following structure:
 
 ```protobuf
 message AgentHealth {
-    bool up = 1;
+    bool healthy = 1;
     fixed64 start_time_unix_nano = 2;
     string last_error = 3;
 }
 ```
 
-#### AgentHealth.up
+#### AgentHealth.healthy
 
-Set to true if the Agent is up and running.
+Set to true if the Agent is up and healthy.
 
 #### AgentHealth.start_time_unix_nano
 
 Timestamp since the Agent is up, i.e. when the agent was started.
 Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
-If "up" is false this field is unused.
+If the agent is not running MUST be set to 0.
 
 #### AgentHealth.last_error
 
-Human-readable error message if the Agent is in erroneous state. Typically set
-when up==false.
+Human-readable error message if the Agent is in erroneous state. SHOULD be set
+when healthy==false.
 
 ### EffectiveConfig Message
 


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opamp-spec/issues/136

- Renamed `up` to `healthy`.
- `start_time_unix_nano` is no longer tied to `up` and is set independently.