### PR TITLE
[editorial] Spec updates for OTel website publication

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -10,7 +10,7 @@ path_base_for_github_subdir:
 spelling: cSpell:ignore bitmask Fluentd varint opamp
 --->
 
-# OpAMP: Open Agent Management Protocol
+# Open Agent Management Protocol
 
 Status: [Beta](https://github.com/open-telemetry/community/blob/47813530864b9fe5a5146f466a58bd2bb94edc72/maturity-matrix.yaml#L57)
 


### PR DESCRIPTION
- Closes #148
- Contributes to https://github.com/open-telemetry/opentelemetry.io/issues/2927
- Minor copyedits only to accompany some of the changes made per the task list below

Updates (task list taken from #148) made in this PR:

- [ ] Demote all headings one level, except for the page title
- [ ] Code quote all `example.com` references
- [ ] Add Hugo front matter
- [ ] **Remove Copyright notice** at the end of the spec page -- the repo has a [LICENSE](https://github.com/open-telemetry/opamp-spec/blob/main/LICENSE) file, and when published on the OTel website, each page has a copyright notice.
- [ ] Replace links:
  - [ ] Outdated: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/otlp.md
    -> https://opentelemetry.io/docs/specs/otlp/

**Local repo preview**: https://github.com/open-telemetry/opamp-spec/blob/9ba5f927bec431e8997d0cdc6e406bd82740cd31/specification.md

/cc @tigrannajaryan @svrnm @cartermp 