### PR TITLE
Add missing "config_hash" field to AgentRemoteConfig

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -1977,6 +1977,7 @@ The message has the following structure:
 ```protobuf
 message AgentRemoteConfig {
   AgentConfigMap config = 1;
+  bytes config_hash = 2;
 }
 ```
 


### PR DESCRIPTION
The field was missing in specification.md, although it is correctly present in opamp.proto.

The filed is now added to specification.md.

Fixes https://github.com/open-telemetry/opamp-spec/issues/120