### PR TITLE
[editorial] Link to semconv OTel website page

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -1021,7 +1021,7 @@ message AgentDescription {
 Attributes that identify the Agent.
 
 Keys/values are according to OpenTelemetry [resource semantic
-conventions](https://github.com/open-telemetry/semantic-conventions/tree/main/docs/resource).
+conventions](https://opentelemetry.io/docs/specs/semconv/resource/).
 
 For standalone running Agents (such as OpenTelemetry Collector) the following
 attributes SHOULD be specified:


### PR DESCRIPTION
- Closes #150 now that the semconv pages are hosted on the OTel website
- Contributes to https://github.com/open-telemetry/opentelemetry.io/issues/2721

/cc @jsuereth @joaopgrassi 