### PR TITLE
[editorial] Fix fb link to PDF

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -3146,7 +3146,7 @@ reduce the number of connections to the Server when a very large number
 
 * [Uber Flipr](https://eng.uber.com/flipr/).
 * Facebook's
-  [Holistic Configuration Management](https://research.fb.com/wp-content/uploads/2016/11/holistic-configuration-management-at-facebook.pdf)
+  [Holistic Configuration Management]( https://research.facebook.com/file/877841159827226/holistic-configuration-management-at-facebook.pdf)
   (push).
 
 ### Security and Certificate Management


### PR DESCRIPTION
- Context: the original link resulted in too many redirects for the OTel website link checker
- Changes the FB PDF URL to be closer to home (resolves a few 3xx's)
- Contributes to https://github.com/open-telemetry/opentelemetry.io/issues/3615

/cc @svrnm