### PR TITLE
[editorial] Use canonical link to "ACME End User Client and Code Signing Certificates"

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -3151,15 +3151,15 @@ reduce the number of connections to the Server when a very large number
 
 ### Security and Certificate Management
 
-* mTLS in Go <https://kofo.dev/how-to-mtls-in-golang>
-* ACME certificate management protocol <https://datatracker.ietf.org/doc/html/rfc8555>
-* ACME for client certificates <http://www.watersprings.org/pub/id/draft-moriarty-acme-client-01.html>
+* [mTLS in Go](https://kofo.dev/how-to-mtls-in-golang)
+* [ACME certificate management protocol](https://datatracker.ietf.org/doc/html/rfc8555)
+* [ACME for client certificates](https://www.watersprings.org/pub/id/draft-moriarty-acme-client-01.html)
 
 ### Cloud Provider Support
 
-* AWS <https://aws.amazon.com/elasticloadbalancing/features/>
-* GCP <https://cloud.google.com/appengine/docs/flexible/go/using-websockets-and-session-affinity>
-* Azure <https://docs.microsoft.com/en-us/azure/application-gateway/application-gateway-websocket>
+* [AWS](https://aws.amazon.com/elasticloadbalancing/features/)
+* [GCP](https://cloud.google.com/appengine/docs/flexible/go/using-websockets-and-session-affinity)
+* [Azure](https://docs.microsoft.com/en-us/azure/application-gateway/application-gateway-websocket)
 
 ### Other
 

--- a/specification.md
+++ b/specification.md
@@ -3153,7 +3153,7 @@ reduce the number of connections to the Server when a very large number
 
 * [mTLS in Go](https://kofo.dev/how-to-mtls-in-golang)
 * [ACME certificate management protocol](https://datatracker.ietf.org/doc/html/rfc8555)
-* [ACME for client certificates](https://www.watersprings.org/pub/id/draft-moriarty-acme-client-01.html)
+* [ACME for client certificates](https://datatracker.ietf.org/doc/draft-moriarty-acme-client/)
 
 ### Cloud Provider Support
 


### PR DESCRIPTION
- Contributes to https://github.com/open-telemetry/opentelemetry.io/issues/3804
- Switches to using canonical link to "ACME End User Client and Code Signing Certificates"
- Replaces raw URLs by proper markdown links so as to match other entries in the **References** section