### PR TITLE
move codeboten to emeritus approver

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ to run the Protobuf compiler and verify the `*.proto` files.
 
 Approvers ([@open-telemetry/opamp-spec-approvers](https://github.com/orgs/open-telemetry/teams/opamp-spec-approvers)):
 
-- [Alex Boten](https://github.com/codeboten), Lightstep
 - [Andy Keller](https://github.com/andykellr), observIQ
 
 Emeritus Approvers
 
+- [Alex Boten](https://github.com/codeboten), Lightstep
 - [Daniel Jaglowski](https://github.com/djaglowski), observIQ
 - [Przemek Maciolek](https://github.com/pmm-sumo), Sumo Logic
 


### PR DESCRIPTION
I've not had time or bandwidth to follow the work in this repo.