### PR TITLE
Fix typos

### DIFF
--- a/proto/opamp.proto
+++ b/proto/opamp.proto
@@ -564,7 +564,7 @@ message AgentDescription {
     //   Agent type, e.g. "io.opentelemetry.collector"
     // - service.namespace if it is used in the environment where the Agent runs.
     // - service.version should be set to version number of the Agent build.
-    // - service.instance.id should be set. It may be be set equal to the Agent's
+    // - service.instance.id should be set. It may be set equal to the Agent's
     //   instance uid (equal to ServerToAgent.instance_uid field) or any other value
     //   that uniquely identifies the Agent in combination with other attributes.
     // - any other attributes that are necessary for uniquely identifying the Agent's

--- a/proto/opamp.proto
+++ b/proto/opamp.proto
@@ -564,7 +564,7 @@ message AgentDescription {
     //   Agent type, e.g. "io.opentelemetry.collector"
     // - service.namespace if it is used in the environment where the Agent runs.
     // - service.version should be set to version number of the Agent build.
-    // - service.instance.id should be set. It may be set equal to the Agent's
+    // - service.instance.id should be set. It may be be set equal to the Agent's
     //   instance uid (equal to ServerToAgent.instance_uid field) or any other value
     //   that uniquely identifies the Agent in combination with other attributes.
     // - any other attributes that are necessary for uniquely identifying the Agent's

--- a/specification.md
+++ b/specification.md
@@ -1108,7 +1108,7 @@ attributes SHOULD be specified:
 - service.name should be set to the same value that the Agent uses in its own telemetry.
 - service.namespace if it is used in the environment where the Agent runs.
 - service.version should be set to version number of the Agent build.
-- service.instance.id should be set. It may be be set equal to the Agent's
+- service.instance.id should be set. It may be set equal to the Agent's
   instance uid (equal to ServerToAgent.instance_uid field) or any other value
   that uniquely identifies the Agent in combination with other attributes.
 - any other attributes that are necessary for uniquely identifying the Agent's


### PR DESCRIPTION
Just some simple typos.
I'm not sure if I'm missing something and these descriptions should be somehow automatically copied to proto files or it had to be corrected manually in these two files (that's how I did it).