### PR TITLE
Add message about available components to AgentDetails

### DIFF
--- a/proto/opamp.proto
+++ b/proto/opamp.proto
@@ -708,6 +708,9 @@ enum AgentCapabilities {
     // know the configured interval and should not make assumptions about it.
     // Status: [Development]
     AgentCapabilities_ReportsHeartbeat               = 0x00002000;
+    // The will report AvailableComponents via the AgentToServer.available_components field.
+    // Status: [Development]    
+    AgentCapabilities_ReportsAvailableComponents     = 0x00004000;
     // Add new capabilities here, continuing with the least significant unused bit.
 }
 

--- a/proto/opamp.proto
+++ b/proto/opamp.proto
@@ -168,6 +168,14 @@ message ComponentDetails {
     // Extra key/value pairs that may be used to describe the component.
     // The key/value pairs are according to semantic conventions, see:
     // https://opentelemetry.io/docs/specs/semconv/
+    //
+    // For example, you may use the "code" semantic conventions to
+    // report the location of the code for a specific component:
+    // https://opentelemetry.io/docs/specs/semconv/attributes-registry/code/
+    // 
+    // Or you may use the "vcs" semantic conventions to report the
+    // repository the component may be a part of:
+    // https://opentelemetry.io/docs/specs/semconv/attributes-registry/vcs/
     repeated KeyValue metadata = 1;
 
     // A map of component ID to sub components details. It can nest as deeply as needed to

--- a/proto/opamp.proto
+++ b/proto/opamp.proto
@@ -609,8 +609,22 @@ message AgentDescription {
     //   with this Agent.
     repeated KeyValue non_identifying_attributes = 2;
 
+    // Details about the components available in the agent.
+    ComponentDetails component_details = 3;
+
     // TODO: add ability to specify related entities (such as the Service the Agent is
     // is responsible/associated with).
+}
+
+message ComponentDetails {
+    // Extra key/value pairs that may be used to describe the component.
+    // The key/value pairs are according to semantic conventions, see:
+    // https://opentelemetry.io/docs/specs/semconv/
+    repeated KeyValue metadata = 1;
+
+    // A map of component ID to sub components details. It can nest as deeply as needed to
+    // describe the underlying system.
+    map<string, ComponentDetails> sub_component_map = 2;
 }
 
 enum AgentCapabilities {

--- a/proto/opamp.proto
+++ b/proto/opamp.proto
@@ -610,7 +610,7 @@ message AgentDescription {
     repeated KeyValue non_identifying_attributes = 2;
 
     // Details about the components available in the agent.
-    map<string, ComponentDetails> component_details = 3;
+    map<string, ComponentDetails> available_components = 3;
 
     // TODO: add ability to specify related entities (such as the Service the Agent is
     // is responsible/associated with).

--- a/proto/opamp.proto
+++ b/proto/opamp.proto
@@ -149,7 +149,7 @@ message CertificateRequest {
     bytes csr = 1;
 }
 
-// AvailableComponents contains metadata relating to the components included 
+// AvailableComponents contains metadata relating to the components included
 // within the agent.
 // status: [Development]
 message AvailableComponents {
@@ -172,7 +172,7 @@ message ComponentDetails {
     // For example, you may use the "code" semantic conventions to
     // report the location of the code for a specific component:
     // https://opentelemetry.io/docs/specs/semconv/attributes-registry/code/
-    // 
+    //
     // Or you may use the "vcs" semantic conventions to report the
     // repository the component may be a part of:
     // https://opentelemetry.io/docs/specs/semconv/attributes-registry/vcs/
@@ -256,6 +256,7 @@ enum ServerToAgentFlags {
     // not include the full AvailableComponents message, but only the hash.
     // If this flag is specified, the agent will populate available_components.components
     // with a full description of the agent's components.
+    // Status: [Development]
     ServerToAgentFlags_ReportAvailableComponents = 0x00000002;
 }
 
@@ -709,7 +710,7 @@ enum AgentCapabilities {
     // Status: [Development]
     AgentCapabilities_ReportsHeartbeat               = 0x00002000;
     // The agent will report AvailableComponents via the AgentToServer.available_components field.
-    // Status: [Development]    
+    // Status: [Development]
     AgentCapabilities_ReportsAvailableComponents     = 0x00004000;
     // Add new capabilities here, continuing with the least significant unused bit.
 }

--- a/proto/opamp.proto
+++ b/proto/opamp.proto
@@ -610,7 +610,7 @@ message AgentDescription {
     repeated KeyValue non_identifying_attributes = 2;
 
     // Details about the components available in the agent.
-    ComponentDetails component_details = 3;
+    map<string, ComponentDetails> component_details = 3;
 
     // TODO: add ability to specify related entities (such as the Service the Agent is
     // is responsible/associated with).

--- a/proto/opamp.proto
+++ b/proto/opamp.proto
@@ -708,7 +708,7 @@ enum AgentCapabilities {
     // know the configured interval and should not make assumptions about it.
     // Status: [Development]
     AgentCapabilities_ReportsHeartbeat               = 0x00002000;
-    // The will report AvailableComponents via the AgentToServer.available_components field.
+    // The agent will report AvailableComponents via the AgentToServer.available_components field.
     // Status: [Development]    
     AgentCapabilities_ReportsAvailableComponents     = 0x00004000;
     // Add new capabilities here, continuing with the least significant unused bit.

--- a/proto/opamp.proto
+++ b/proto/opamp.proto
@@ -91,6 +91,10 @@ message AgentToServer {
     // A custom message sent from an Agent to the Server.
     // Status: [Development]
     CustomMessage custom_message = 13;
+
+    // A message indicating the components that are available for configuration on the agent.
+    // Status: [Development]
+    AvailableComponents available_components = 14;
 }
 
 enum AgentToServerFlags {
@@ -144,6 +148,33 @@ message CertificateRequest {
     // certificate.
     bytes csr = 1;
 }
+
+// AvailableComponents contains metadata relating to the components included 
+// within the agent.
+// status: [Development]
+message AvailableComponents {
+    // A map of a unique component ID to details about the component.
+    // This may be omitted from the message if the server has not
+    // explicitly requested it be sent by setting the ReportAvailableComponents
+    // flag in the previous ServerToAgent message.
+    map<string, ComponentDetails> components = 1;
+
+    // Agent-calculated hash of the components.
+    // This hash should be included in every AvailableComponents message.
+    bytes hash = 2;
+ }
+
+message ComponentDetails {
+    // Extra key/value pairs that may be used to describe the component.
+    // The key/value pairs are according to semantic conventions, see:
+    // https://opentelemetry.io/docs/specs/semconv/
+    repeated KeyValue metadata = 1;
+
+    // A map of component ID to sub components details. It can nest as deeply as needed to
+    // describe the underlying system.
+    map<string, ComponentDetails> sub_component_map = 2;
+}
+
 
 message ServerToAgent {
     // Agent instance uid. MUST match the instance_uid field in AgentToServer message.
@@ -212,6 +243,12 @@ enum ServerToAgentFlags {
     // AgentToServer.sequence_num values.
     // The Server asks the Agent to report full status.
     ServerToAgentFlags_ReportFullState = 0x00000001;
+
+    // ReportAvailableComponents flag can be used by the server if the Agent did
+    // not include the full AvailableComponents message, but only the hash.
+    // If this flag is specified, the agent will populate available_components.components
+    // with a full description of the agent's components.
+    ServerToAgentFlags_ReportAvailableComponents = 0x00000002;
 }
 
 enum ServerCapabilities {
@@ -609,22 +646,8 @@ message AgentDescription {
     //   with this Agent.
     repeated KeyValue non_identifying_attributes = 2;
 
-    // Details about the components available in the agent.
-    map<string, ComponentDetails> available_components = 3;
-
     // TODO: add ability to specify related entities (such as the Service the Agent is
     // is responsible/associated with).
-}
-
-message ComponentDetails {
-    // Extra key/value pairs that may be used to describe the component.
-    // The key/value pairs are according to semantic conventions, see:
-    // https://opentelemetry.io/docs/specs/semconv/
-    repeated KeyValue metadata = 1;
-
-    // A map of component ID to sub components details. It can nest as deeply as needed to
-    // describe the underlying system.
-    map<string, ComponentDetails> sub_component_map = 2;
 }
 
 enum AgentCapabilities {

--- a/specification.md
+++ b/specification.md
@@ -2986,7 +2986,7 @@ message will have the agent computed hash set, with an empty map for components.
 
 The OpAMP server may use this hash to determine whether it remembers the set of
 AvailableComponents or not. If the hash is not found on the OpAMP server, the server
-may request the full components map is reported by setting the ReportAvailableComponents
+may request for the full components map to be reported by setting the ReportAvailableComponents
 flag in the ServerToAgent message. If this flag is specified, then the Agent will
 populate the components field with a full description of the available components.
 

--- a/specification.md
+++ b/specification.md
@@ -2908,32 +2908,32 @@ components for a custom build of [OpenTelemetry Collector](https://github.com/op
 {
   "receivers": {
     "sub_component_map": {
-      "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver@v0.107.0": {
+      "hostmetrics": {
         "metadata": {
-          "type": "hostmetrics",
+          "code.namespace": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver@v0.107.0",
         }
       }
     }
   },
   "processors": {
     "sub_component_map": {
-      "go.opentelemetry.io/collector/processor/batchprocessor@v0.107.0": {
+      "batch": {
         "metadata": {
-          "type": "batch",
+          "code.namespace": "go.opentelemetry.io/collector/processor/batchprocessor@v0.107.0"
         }
       },
-      "github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor@v0.107.0": {
+      "transform": {
         "metadata": {
-          "type": "transform",
+          "code.namespace": "github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor@v0.107.0"
         }
       },
     }
   },
   "exporters": {
     "sub_component_map": {
-      "go.opentelemetry.io/collector/exporter/nopexporter@v0.107.0": {
+      "nop": {
         "metadata": {
-          "type": "nop",
+          "code.namespace": "go.opentelemetry.io/collector/exporter/nopexporter@v0.107.0"
         }
       }
     }

--- a/specification.md
+++ b/specification.md
@@ -1168,10 +1168,12 @@ This field gives a description of what components are available, as well
 as extra metadata about the components.
 
 The structure of ComponentDetails DOES NOT need to be a 1-to-1 match with
-the ComponentHealth structure. ComponentHealth generally refers to instances of
-components, while ComponentDetails refers to the available types of components.
+the ComponentHealth structure. ComponentHealth generally refers to currently running instances of
+components, while ComponentDetails refers to the available types of components, 
+which may not be necessarily running currently. It is also possible that the same component 
+type may have more than one running instance.
 
-This field is not required to be specified.
+This is an optional field.
 
 #### ComponentDetails Message
 
@@ -1203,7 +1205,7 @@ describe the underlying system.
 ###### OpenTelemetry Collector
 
 Here is an example of how ComponentDetails could hold information regarding the included
-components for a custom build collector:
+components for a custom build of [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector)::
 
 ```jsonc
 {

--- a/specification.md
+++ b/specification.md
@@ -40,6 +40,7 @@ Status: [Beta]
       - [AgentToServer.connection_settings_request](#agenttoserverconnection_settings_request)
       - [AgentToServer.custom_capabilities](#agenttoservercustom_capabilities)
       - [AgentToServer.custom_message](#agenttoservercustom_message)
+      - [AgentToServer.available_components](#agenttoserveravailable_components)
     + [ServerToAgent Message](#servertoagent-message)
       - [ServerToAgent.instance_uid](#servertoagentinstance_uid)
       - [ServerToAgent.error_response](#servertoagenterror_response)
@@ -63,13 +64,6 @@ Status: [Beta]
     + [AgentDescription Message](#agentdescription-message)
       - [AgentDescription.identifying_attributes](#agentdescriptionidentifying_attributes)
       - [AgentDescription.non_identifying_attributes](#agentdescriptionnon_identifying_attributes)
-      - [AgentDescription.available_components](#agentdescriptionavailable_components)
-    + [ComponentDetails Message](#componentdetails-message)
-      - [ComponentDetails.metadata](#componentdetailsmetadata)
-      - [ComponentDetails.sub_component_map](#componentdetailssub_component_map)
-      - [Examples](#examples)
-        * [OpenTelemetry Collector](#opentelemetry-collector)
-        * [Fluent Bit](#fluent-bit)
     + [ComponentHealth Message](#componenthealth-message)
       - [ComponentHealth.healthy](#componenthealthhealthy)
       - [ComponentHealth.start_time_unix_nano](#componenthealthstart_time_unix_nano)
@@ -170,7 +164,7 @@ Status: [Beta]
       - [CustomMessage.capability](#custommessagecapability)
       - [CustomMessage.type](#custommessagetype)
       - [CustomMessage.data](#custommessagedata)
-    + [Examples](#examples-1)
+    + [Examples](#examples)
       - [Pause/Resume Example](#pauseresume-example)
         * [Agent Connection](#agent-connection)
         * [Pause](#pause)
@@ -179,6 +173,16 @@ Status: [Beta]
         * [Agent Connection](#agent-connection-1)
         * [FindServices](#findservices)
         * [FindServicesResponse](#findservicesresponse)
+  * [AvailableComponents Message](#availablecomponents-message)
+    + [AvailableComponents.components](#availablecomponentscomponents)
+      - [Examples](#examples-1)
+        * [OpenTelemetry Collector](#opentelemetry-collector)
+        * [Fluent Bit](#fluent-bit)
+    + [AvailableComponents.hash](#availablecomponentshash)
+    + [Initial Handshake](#initial-handshake)
+    + [ComponentDetails Message](#componentdetails-message)
+      - [ComponentDetails.metadata](#componentdetailsmetadata)
+      - [ComponentDetails.sub_component_map](#componentdetailssub_component_map)
 - [Connection Management](#connection-management)
   * [Establishing Connection](#establishing-connection)
   * [Closing Connection](#closing-connection)
@@ -696,7 +700,7 @@ Status: [Development]
 
 A message listing the components available in the Agent.
 
-See [AvailableComponents](#availablecomponents) message for details.
+See [AvailableComponents](#availablecomponents-message) message for details.
 
 #### ServerToAgent Message
 
@@ -2887,7 +2891,8 @@ message AvailableComponents {
 
 #### AvailableComponents.components
 
-The components field contains a map of a unique ID to a [ComponentsDetails](#componentdetails) message.
+The components field contains a map of a unique ID
+to a [ComponentsDetails](#componentdetails-message) message.
 This field may be omitted from the message if the OpAMP server has not explicitly
 requested it by setting the ReportAvailableComponents flag in the preceding
 ServerToAgent message.
@@ -2971,7 +2976,7 @@ Here's an example of how Fluent Bit could report what components it has availabl
 #### AvailableComponents.hash
 
 The agent-calculated hash of the components field. The agent MUST include this hash
-if it has the ability to report the components it has available. 
+if it has the ability to report the components it has available.
 
 #### Initial Handshake
 
@@ -2979,7 +2984,7 @@ In order to reduce the amount of data transmitted, the AvailableComponents messa
 does not initially contain the entire components map. Instead, the AvailableComponents
 message will have the agent computed hash set, with an empty map for components.
 
-The OpAMP server may use this hash to determine whether it remembers the set of 
+The OpAMP server may use this hash to determine whether it remembers the set of
 AvailableComponents or not. If the hash is not found on the OpAMP server, the server
 may request the full components map is reported by setting the ReportAvailableComponents
 flag in the ServerToAgent message. If this flag is specified, then the Agent will

--- a/specification.md
+++ b/specification.md
@@ -1117,6 +1117,7 @@ The AgentDescription message has the following structure:
 message AgentDescription {
     repeated KeyValue identifying_attributes = 1;
     repeated KeyValue non_identifying_attributes = 2;
+    map<string, ComponentDetails> component_details = 3;
 }
 ```
 
@@ -1204,38 +1205,36 @@ describe the underlying system.
 Here is an example of how ComponentDetails could hold information regarding the included
 components for a custom build collector:
 
-```json
+```jsonc
 {
-  "sub_component_data": {
-    "receivers": {
-      "sub_component_data": {
-        "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver@v0.107.0": {
-          "metadata": {
-            "type": "hostmetrics",
-          }
+  "receivers": {
+    "sub_component_data": {
+      "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver@v0.107.0": {
+        "metadata": {
+          "type": "hostmetrics",
         }
       }
-    },
-    "processors": {
-      "sub_component_data": {
-        "go.opentelemetry.io/collector/processor/batchprocessor@v0.107.0": {
-          "metadata": {
-            "type": "batch",
-          }
-        },
-        "github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor@v0.107.0": {
-          "metadata": {
-            "type": "transform",
-          }
-        },
-      }
-    },
-    "exporters": {
-      "sub_component_data": {
-        "go.opentelemetry.io/collector/exporter/nopexporter@v0.107.0": {
-          "metadata": {
-            "type": "nop",
-          }
+    }
+  },
+  "processors": {
+    "sub_component_data": {
+      "go.opentelemetry.io/collector/processor/batchprocessor@v0.107.0": {
+        "metadata": {
+          "type": "batch",
+        }
+      },
+      "github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor@v0.107.0": {
+        "metadata": {
+          "type": "transform",
+        }
+      },
+    }
+  },
+  "exporters": {
+    "sub_component_data": {
+      "go.opentelemetry.io/collector/exporter/nopexporter@v0.107.0": {
+        "metadata": {
+          "type": "nop",
         }
       }
     }
@@ -1248,30 +1247,28 @@ components for a custom build collector:
 
 Here's an example of how Fluent Bit could report what components it has available.
 
-```json
+```jsonc
 {
-  "sub_component_data": {
-    "input": {
-      "sub_component_data": {
-        "tail": {}
-      }
-    },
-    "parser": {
-      "sub_component_data": {
-        "json": {}
-      }
-    },
-    "filter": {
-      "sub_component_data": {
-        "lua": {},
-        "modify": {}
-      }
-    },
-    "output": {
-      "sub_component_data": {
-        "null": {},
-        "file": {},
-      }
+  "input": {
+    "sub_component_data": {
+      "tail": {}
+    }
+  },
+  "parser": {
+    "sub_component_data": {
+      "json": {}
+    }
+  },
+  "filter": {
+    "sub_component_data": {
+      "lua": {},
+      "modify": {}
+    }
+  },
+  "output": {
+    "sub_component_data": {
+      "null": {},
+      "file": {},
     }
   }
 }

--- a/specification.md
+++ b/specification.md
@@ -698,7 +698,8 @@ See [CustomMessage](#custommessage) message for details.
 
 Status: [Development]
 
-A message listing the components available in the Agent.
+A message listing the components available in the Agent. This field SHOULD be
+reported if and only if the ReportsAvailableComponents capability is set.
 
 See [AvailableComponents](#availablecomponents-message) message for details.
 

--- a/specification.md
+++ b/specification.md
@@ -63,6 +63,13 @@ Status: [Beta]
     + [AgentDescription Message](#agentdescription-message)
       - [AgentDescription.identifying_attributes](#agentdescriptionidentifying_attributes)
       - [AgentDescription.non_identifying_attributes](#agentdescriptionnon_identifying_attributes)
+      - [AgentDescription.component_details](#agentdescriptioncomponent_details)
+    + [ComponentDetails Message](#componentdetails-message)
+      - [ComponentDetails.metadata](#componentdetailsmetadata)
+      - [ComponentDetails.sub_component_map](#componentdetailssub_component_map)
+      - [Examples](#examples)
+        * [OpenTelemetry Collector](#opentelemetry-collector)
+        * [Fluent Bit](#fluent-bit)
     + [ComponentHealth Message](#componenthealth-message)
       - [ComponentHealth.healthy](#componenthealthhealthy)
       - [ComponentHealth.start_time_unix_nano](#componenthealthstart_time_unix_nano)
@@ -163,7 +170,7 @@ Status: [Beta]
       - [CustomMessage.capability](#custommessagecapability)
       - [CustomMessage.type](#custommessagetype)
       - [CustomMessage.data](#custommessagedata)
-    + [Examples](#examples)
+    + [Examples](#examples-1)
       - [Pause/Resume Example](#pauseresume-example)
         * [Agent Connection](#agent-connection)
         * [Pause](#pause)
@@ -1151,6 +1158,124 @@ The following attributes SHOULD be included:
   environment it runs in.
 - any user-defined attributes that the end user would like to associate with
   this Agent.
+
+##### AgentDescription.component_details
+
+Details about the available components in the agent.
+
+This field gives a description of what components are available, as well
+as extra metadata about the components.
+
+The structure of ComponentDetails DOES NOT need to be a 1-to-1 match with
+the ComponentHealth structure. ComponentHealth generally refers to instances of
+components, while ComponentDetails refers to the available types of components.
+
+This field is not required to be specified.
+
+#### ComponentDetails Message
+
+Status: [Beta]
+
+The ComponentDetails message has the following structure:
+
+```protobuf
+message ComponentDetails {
+    map<string, ComponentDetails> sub_component_map = 1;
+    repeated KeyValue metadata = 2;
+}
+```
+
+##### ComponentDetails.metadata
+
+Extra key/value pairs that may be used to describe the component.
+
+The key/value pairs are according to semantic conventions, see
+the [OpenTelemetry Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/) for more information.
+
+##### ComponentDetails.sub_component_map
+
+A map of component ID to sub components details. It can nest as deeply as needed to
+describe the underlying system.
+
+##### Examples
+
+###### OpenTelemetry Collector
+
+Here is an example of how ComponentDetails could hold information regarding the included
+components for a custom build collector:
+
+```json
+{
+  "sub_component_data": {
+    "receivers": {
+      "sub_component_data": {
+        "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver@v0.107.0": {
+          "metadata": {
+            "type": "hostmetrics",
+          }
+        }
+      }
+    },
+    "processors": {
+      "sub_component_data": {
+        "go.opentelemetry.io/collector/processor/batchprocessor@v0.107.0": {
+          "metadata": {
+            "type": "batch",
+          }
+        },
+        "github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor@v0.107.0": {
+          "metadata": {
+            "type": "transform",
+          }
+        },
+      }
+    },
+    "exporters": {
+      "sub_component_data": {
+        "go.opentelemetry.io/collector/exporter/nopexporter@v0.107.0": {
+          "metadata": {
+            "type": "nop",
+          }
+        }
+      }
+    }
+  }
+  // ... Component list continues for extensions and collectors ...
+}
+```
+
+###### Fluent Bit
+
+Here's an example of how Fluent Bit could report what components it has available.
+
+```json
+{
+  "sub_component_data": {
+    "input": {
+      "sub_component_data": {
+        "tail": {}
+      }
+    },
+    "parser": {
+      "sub_component_data": {
+        "json": {}
+      }
+    },
+    "filter": {
+      "sub_component_data": {
+        "lua": {},
+        "modify": {}
+      }
+    },
+    "output": {
+      "sub_component_data": {
+        "null": {},
+        "file": {},
+      }
+    }
+  }
+}
+```
 
 #### ComponentHealth Message
 

--- a/specification.md
+++ b/specification.md
@@ -2903,7 +2903,7 @@ ServerToAgent message.
 ###### OpenTelemetry Collector
 
 Here is an example of how ComponentDetails could hold information regarding the included
-components for a custom build of [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector):
+components for a custom build of the [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector):
 
 ```jsonc
 {

--- a/specification.md
+++ b/specification.md
@@ -63,7 +63,7 @@ Status: [Beta]
     + [AgentDescription Message](#agentdescription-message)
       - [AgentDescription.identifying_attributes](#agentdescriptionidentifying_attributes)
       - [AgentDescription.non_identifying_attributes](#agentdescriptionnon_identifying_attributes)
-      - [AgentDescription.component_details](#agentdescriptioncomponent_details)
+      - [AgentDescription.available_components](#agentdescriptionavailable_components)
     + [ComponentDetails Message](#componentdetails-message)
       - [ComponentDetails.metadata](#componentdetailsmetadata)
       - [ComponentDetails.sub_component_map](#componentdetailssub_component_map)
@@ -1117,7 +1117,7 @@ The AgentDescription message has the following structure:
 message AgentDescription {
     repeated KeyValue identifying_attributes = 1;
     repeated KeyValue non_identifying_attributes = 2;
-    map<string, ComponentDetails> component_details = 3;
+    map<string, ComponentDetails> available_components = 3;
 }
 ```
 
@@ -1160,7 +1160,7 @@ The following attributes SHOULD be included:
 - any user-defined attributes that the end user would like to associate with
   this Agent.
 
-##### AgentDescription.component_details
+##### AgentDescription.available_components
 
 Details about the available components in the agent.
 
@@ -1169,8 +1169,8 @@ as extra metadata about the components.
 
 The structure of ComponentDetails DOES NOT need to be a 1-to-1 match with
 the ComponentHealth structure. ComponentHealth generally refers to currently running instances of
-components, while ComponentDetails refers to the available types of components, 
-which may not be necessarily running currently. It is also possible that the same component 
+components, while ComponentDetails refers to the available types of components,
+which may not be necessarily running currently. It is also possible that the same component
 type may have more than one running instance.
 
 This is an optional field.

--- a/specification.md
+++ b/specification.md
@@ -1180,8 +1180,8 @@ The ComponentDetails message has the following structure:
 
 ```protobuf
 message ComponentDetails {
-    map<string, ComponentDetails> sub_component_map = 1;
-    repeated KeyValue metadata = 2;
+    repeated KeyValue metadata = 1;
+    map<string, ComponentDetails> sub_component_map = 2;    
 }
 ```
 

--- a/specification.md
+++ b/specification.md
@@ -3004,8 +3004,6 @@ and may be omitted if the hash has not changed from its previous value.
 
 #### ComponentDetails Message
 
-Status: [Beta]
-
 The ComponentDetails messaged describes a component of the Agent.
 
 The structure of ComponentDetails DOES NOT need to be a 1-to-1 match with
@@ -3019,7 +3017,7 @@ The ComponentDetails message has the following structure:
 ```protobuf
 message ComponentDetails {
     repeated KeyValue metadata = 1;
-    map<string, ComponentDetails> sub_component_map = 2;    
+    map<string, ComponentDetails> sub_component_map = 2;
 }
 ```
 

--- a/specification.md
+++ b/specification.md
@@ -2984,6 +2984,9 @@ In order to reduce the amount of data transmitted, the AvailableComponents messa
 does not initially contain the entire components map. Instead, the AvailableComponents
 message will have the agent computed hash set, with an empty map for components.
 
+The initial AgentToServer message SHOULD contain the AvailableComponents message
+with just the agent computed hash set.
+
 The OpAMP server may use this hash to determine whether it remembers the set of
 AvailableComponents or not. If the hash is not found on the OpAMP server, the server
 may request for the full components map to be reported by setting the ReportAvailableComponents

--- a/specification.md
+++ b/specification.md
@@ -2978,6 +2978,8 @@ Here's an example of how Fluent Bit could report what components it has availabl
 
 The agent-calculated hash of the components field. The agent MUST include this hash
 if it has the ability to report the components it has available.
+Its format is determined by the agent.
+The hash SHOULD be the same for any agent that has the same set of components.
 
 #### Initial Handshake
 


### PR DESCRIPTION
This PR adds a new ComponentDetails type that allows agents to communicate metadata relating to the components available in the agent.