### PR TITLE
Change PackageStatus.download_details.download_bytes_per_second to double

### DIFF
--- a/proto/opamp.proto
+++ b/proto/opamp.proto
@@ -866,7 +866,7 @@ message PackageDownloadDetails {
     double download_percent = 1;
 
     // The current package download rate in bytes per second.
-    uint64 download_bytes_per_second = 2;
+    double download_bytes_per_second = 2;
 }
 
 // The status of this package.

--- a/specification.md
+++ b/specification.md
@@ -1438,7 +1438,7 @@ It should only be set if the status is `DOWNLOADING`.
 ```protobuf
 message PackageDownloadDetails {
   double download_percent = 1;
-  uint64 download_bytes_per_second = 2;
+  double download_bytes_per_second = 2;
 }
 ```
 


### PR DESCRIPTION
As suggested in the implementation PR (https://github.com/open-telemetry/opamp-go/pull/341), the download rate should be a double (float64 in go).