### PR TITLE
Add spec change for updating capabilities after initial message

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -560,6 +560,14 @@ in the future such that old Agents automatically report that they don't
 support the new capability.
 This field MUST be always set.
 
+This field MUST be set in the first AgentToServer sent by the Agent and MAY be
+omitted in subsequent AgentToServer messages by setting it to
+UnspecifiedAgentCapability value. An Agent MAY update its'
+AgentCapabilities.AcceptsRemoteConfig capability at ANY time after the first
+message. If the capability is enabled, the server MAY offer a new remote
+configuration. If the capability is dsiabled, the server MUST NOT send a remote
+configuration update.
+
 ```protobuf
 enum AgentCapabilities {
     // The capabilities field is unspecified.


### PR DESCRIPTION
Following from [this comment](https://github.com/open-telemetry/opamp-go/pull/366#issuecomment-2751917718) from @tigrannajaryan, this PR updates the spec to make it explicitly allowed to update the remote config capacity after the initial capacity.

Please let me know if this is not the right place for this to go, it felt most accurate as there's a similar section in the [servertoagent.capabilities](https://github.com/open-telemetry/opamp-spec/blob/main/specification.md#servertoagentcapabilities) part of the spec:
> This field MUST be set in the first ServerToAgent sent by the Server and MAY be omitted in subsequent ServerToAgent messages by setting it to UnspecifiedServerCapability value.