### PR TITLE
CI: Detect protobuf breaking changes

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -55,3 +55,22 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - run: make docker-pull
       - run: make gen-proto
+
+  breaking-change:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      # breaking-change checks against last published release which is determined
+      # using the last published tag
+      - name: Get tags
+        run: git fetch --tags origin
+      - name: Docker pull
+        run: make docker-pull
+      - name: Run make breaking-change with json output to annotate PR
+        # Formats JSON output into Github workflow commands
+       # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message
+        run: >
+          BUF_FLAGS="--error-format json" make -s breaking-change
+          | jq -rs '.[] | "::error file=\(.path),line=\(.start_line),endLine=\(.end_line),title=Buf detected breaking change \(.type)::\(.message)"'
+          ; (exit ${PIPESTATUS[0]})

--- a/proto/buf.yaml
+++ b/proto/buf.yaml
@@ -1,0 +1,9 @@
+version: v1
+
+# See https://buf.build/docs/configuration/v1/buf-yaml/
+breaking:
+  use:
+    - WIRE
+  ignore:
+    - opentelemetry/proto/profiles
+    - opentelemetry/proto/collector/profiles


### PR DESCRIPTION
## Summary

Add a step to detect breaking changes in protobuf. It's similar to the [open-telemetry/opentelemetry-proto](https://github.com/open-telemetry/opentelemetry-proto/blob/57a5849f7887b7fc149aa651de313dabd3e4704d/.github/workflows/build-check.yaml#L111-L127) approach.

Related Issue: #213

### Make

- New `breaking-changes` make target:  It compares the last tagged schema with the current.
- Update `docker-pull` target to pull buf too.

### CI

- Extend the **Checks** workflow for detecting protobuf schema breaking changes.

### Other

- Add a buf configuration YAML file to `proto` directory. It's used by buf.

Used Images:

- [otel/build-protobuf:0.14.0](https://hub.docker.com/r/otel/build-protobuf)
- :new: [bufbuild/buf:1.7.0](https://hub.docker.com/r/bufbuild/buf)
  - License: Apache License Version 2.0

The versions are not up-to-date but works. If you would like to update them, please let me know and I can create another PR.

## Logs

:exclamation: I'm not an expert of protobuf, please do not forget to check logs are valid.

<details>
<summary>CI Log - Sample Breaking Change</summary>

Remove AgentToServer.sequence_num

Exit Code: 2

```shell
Run BUF_FLAGS="--error-format json" make -s breaking-change | jq -rs '.[] | "::error file=\(.path),line=\(.start_line),endLine=\(.end_line),title=Buf detected breaking change \(.type)::\(.message)"' ; (exit ${PIPESTATUS[0]})
make: *** [Makefile:96: breaking-change] Error 100
Error: Previously present field "2" with name "sequence_num" on message "AgentToServer" was deleted without reserving the number "2".
Error: Process completed with exit code 2.
```
</details>

<details>
<summary>CI Log - Without any Changes</summary>

Exit Code: 0

```shell
Run BUF_FLAGS="--error-format json" make -s breaking-change | jq -rs '.[] | "::error file=\(.path),line=\(.start_line),endLine=\(.end_line),title=Buf detected breaking change \(.type)::\(.message)"' ; (exit ${PIPESTATUS[0]})
```

</details>