### PR TITLE
Restrict capabilities that may change after the first message

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -16,6 +16,9 @@ fenced-code-language: false
 # MD022/blanks-around-headings/blanks-around-headers - Headings should be surrounded by blank lines
 MD022: false
 
+# MD024/no-duplicate-heading - Multiple headings with the same content
+MD024: false
+
 # MD025/single-title/single-h1 - Multiple top-level headings in the same document
 MD025: false
 
@@ -24,3 +27,10 @@ MD032: false
 
 # MD034/no-bare-urls - Bare URL used
 MD034: false
+
+# MD041/first-line-heading/first-line-h1 - First line in a file should be a top-level heading
+# We use Hugo comments at the top.
+MD041: false
+
+# MD059/descriptive-link-text - Link text should be descriptive
+MD059: false

--- a/specification.md
+++ b/specification.md
@@ -589,8 +589,14 @@ in the future such that old Agents automatically report that they don't
 support the new capability.
 This field MUST be always set.
 
-An Agent MAY update any of its capabilities at any time after the first
-message. The server MUST respect the Agent's changes, ensuring that the
+An Agent MAY update (enabled or disable) some of its capabilities at any time after
+the first message. The following capabilities only may be updated after the first
+message:
+
+- AcceptsRemoteConfig
+- ReportsRemoteConfig
+
+The server MUST respect the Agent's capability changes, ensuring that the
 subsequent messages are sent correctly. If the server sends a part of its
 messages corresponding to a capability the Agent doesn't support, the Agent
 SHOULD ignore it.


### PR DESCRIPTION
We made this decision a while back but forgot to update the spec: https://github.com/open-telemetry/opamp-go/pull/366#issuecomment-2751917718