### PR TITLE
Add OpenTelemetry guidelines doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This repository contains Open Agent Management Protocol (OpAMP)
 [specification](specification.md) and Protobuf definitions in [proto](proto) directory.
 
 See [releases here](https://github.com/open-telemetry/opamp-spec/releases) and [changelog here](CHANGELOG.md).
+Additional standalone guidance for instrumentation runtimes is in
+[opentelemetry-guidelines.md](opentelemetry-guidelines.md).
 
 ## Contributing
 

--- a/opentelemetry-guidelines.md
+++ b/opentelemetry-guidelines.md
@@ -1,0 +1,33 @@
+# OpenTelemetry Guidelines
+
+This document provides guidance for language instrumentation agents that use
+OpAMP.
+
+## Scope
+
+This guidance is intended for OpenTelemetry language agents that run as part of an instrumented
+application process. Examples include auto-instrumentation language agents and similar
+instrumentation runtimes built with OpenTelemetry SDKs.
+
+This guidance does not apply to standalone agents such as the OpenTelemetry
+Collector.
+
+## Identifying Attributes
+
+Language instrumentation agents SHOULD copy all attributes from the
+OpenTelemetry SDK `Resource` into `AgentDescription.identifying_attributes`.
+
+Additional identifying attributes MAY be included if they are needed to
+uniquely identify the agent in the deployment environment.
+
+## Non-identifying Attributes
+
+Language instrumentation agents SHOULD leave
+`AgentDescription.non_identifying_attributes` empty.
+
+## Rationale
+
+For language instrumentation agents, the OpenTelemetry SDK `Resource` already
+defines the identity of the telemetry source. Reusing those attributes in OpAMP
+keeps the agent identity aligned with the identity used by the telemetry that
+the agent produces.

--- a/opentelemetry-guidelines.md
+++ b/opentelemetry-guidelines.md
@@ -14,20 +14,26 @@ Collector.
 
 ## Identifying Attributes
 
-Language instrumentation agents SHOULD copy all attributes from the
-OpenTelemetry SDK `Resource` into `AgentDescription.identifying_attributes`.
+Language instrumentation agents MUST copy the following OpenTelemetry SDK
+`Resource` attributes into `AgentDescription.identifying_attributes`:
 
-Additional identifying attributes MAY be included if they are needed to
-uniquely identify the agent in the deployment environment.
+- `service.name`
+- `service.instance.id`
+- `service.namespace.name`, if present
+
+These identifying attributes MUST match the values that the agent uses in the
+Resource of its own telemetry.
 
 ## Non-identifying Attributes
 
-Language instrumentation agents SHOULD leave
-`AgentDescription.non_identifying_attributes` empty.
+Language instrumentation agents SHOULD copy all other OpenTelemetry SDK
+`Resource` attributes into `AgentDescription.non_identifying_attributes`,
+excluding those added to the identifying attributes (above).
 
 ## Rationale
 
-For language instrumentation agents, the OpenTelemetry SDK `Resource` already
-defines the identity of the telemetry source. Reusing those attributes in OpAMP
-keeps the agent identity aligned with the identity used by the telemetry that
-the agent produces.
+For language instrumentation agents, the `service.*` attributes listed above
+define the identity that OpAMP uses to associate an agent with its telemetry.
+Copying the remaining Resource attributes into
+`AgentDescription.non_identifying_attributes` preserves useful descriptive
+context without expanding the agent identity beyond those service attributes.


### PR DESCRIPTION
This follows #310.

It creates a new document instead of polluting the general high level OpAMP spec with tedious details about actual behavior. 