### PR TITLE
Add Duplicate instance_uid detection section

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -213,6 +213,7 @@ Status: [Beta]
     + [Plain HTTP Transport](#plain-http-transport-1)
   * [Restoring WebSocket Connection](#restoring-websocket-connection)
   * [Duplicate WebSocket Connections](#duplicate-websocket-connections)
+    + [Duplicate instance_uid Detection](#duplicate-instance_uid-detection)
   * [Authentication](#authentication)
   * [Bad Request](#bad-request)
   * [Retrying Messages](#retrying-messages)
@@ -3364,6 +3365,18 @@ The Server SHOULD detect duplicate `instance_uid`s (which may happen for example
 when Agents are using bad UID generators or due to cloning of the VMs where the
 Agent runs). When a duplicate `instance_uid` is detected, Server SHOULD generate
 a new `instance_uid`, and send it as `new_instance_uid` value of AgentIdentification.
+
+#### Duplicate instance_uid Detection
+
+A server may be able to detect agents connecting with duplicate `instance_uid` values.
+Detection mechanisms are implementation specific.
+Duplicate detection is desirable in instances where the server seeks to protect against
+`instance_uid` reuse or impersonation.
+
+If this occurs, the Server MAY disconnect or deny serving requests from duplicate
+instances.
+The Server SHOULD generate a new `instance_uid`, and send it as the `new_instance_uid`
+value of AgentIdentification of the `ServerToAgent` response.
 
 ### Authentication
 

--- a/specification.md
+++ b/specification.md
@@ -213,7 +213,7 @@ Status: [Beta]
     + [Plain HTTP Transport](#plain-http-transport-1)
   * [Restoring WebSocket Connection](#restoring-websocket-connection)
   * [Duplicate WebSocket Connections](#duplicate-websocket-connections)
-    + [Duplicate instance_uid Detection](#duplicate-instance_uid-detection)
+  * [Duplicate instance_uid Detection](#duplicate-instance_uid-detection)
   * [Authentication](#authentication)
   * [Bad Request](#bad-request)
   * [Retrying Messages](#retrying-messages)
@@ -3366,7 +3366,7 @@ when Agents are using bad UID generators or due to cloning of the VMs where the
 Agent runs). When a duplicate `instance_uid` is detected, Server SHOULD generate
 a new `instance_uid`, and send it as `new_instance_uid` value of AgentIdentification.
 
-#### Duplicate instance_uid Detection
+### Duplicate instance_uid Detection
 
 A server may be able to detect agents connecting with duplicate `instance_uid` values.
 Detection mechanisms are implementation specific.


### PR DESCRIPTION
As discussed in OpAMP SIG meeting (April 14, 2026), we are adding a section that applies the same approach as duplicate websocket detection to duplicate `instance_uid` detection.
I've added a brief description for motive, but have left to duplicate detection mechanism as an implementation specific detail

- Closes: https://github.com/open-telemetry/opamp-spec/issues/20
