### PR TITLE
Document HTTP OpAMP routing through the Collector

### DIFF
--- a/opentelemetry-guidelines.md
+++ b/opentelemetry-guidelines.md
@@ -66,3 +66,30 @@ define the identity that OpAMP uses to associate an agent with its telemetry.
 Copying the remaining Resource attributes into
 `AgentDescription.non_identifying_attributes` preserves useful descriptive
 context without expanding the agent identity beyond those service attributes.
+
+## Routing instrumentation agents through the Collector
+
+OpenTelemetry instrumentation agents typically send telemetry data through the
+Collector. When these agents also use OpAMP, they can route HTTP OpAMP traffic
+through the Collector as well.
+
+For the plain HTTP transport, Collector distributions that include the
+`http_forwarder` extension can proxy OpAMP requests by configuring the extension
+to listen for OpAMP requests and forward them to the OpAMP backend:
+
+```yaml
+extensions:
+  http_forwarder/opamp:
+    ingress:
+      endpoint: localhost:4320
+    egress:
+      endpoint: https://opamp.example.com
+
+service:
+  extensions: [http_forwarder/opamp]
+```
+
+Port `4320` SHOULD be used for this Collector listener. The host part should
+match the deployment model; for example, use `localhost:4320` when the OpAMP
+client and Collector run on the same host, or another appropriate interface when
+remote clients connect to the Collector.


### PR DESCRIPTION
Document guidance for routing OpAMP traffic from instrumentation agents through
the OpenTelemetry Collector using the `http_forwarder` extension.

The documentation examples already use port `4320` for this OpAMP listener. This
change makes that recommendation explicit and shows a minimal Collector
configuration snippet for forwarding OpAMP HTTP traffic to an OpAMP backend.

Related PR: https://github.com/open-telemetry/opamp-spec/pull/323