### PR TITLE
Add Message Attestation for ServerToAgent messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## Unreleased
+
+* Add `Message Attestation` section to specification.md describing an
+  optional, end-to-end integrity mechanism for `ServerToAgent` messages
+  based on X.509 certificate chains and a per-connection trust handshake.
+  Strict opt-in: existing OpAMP deployments are unaffected until both
+  Server and Agent opt in.
+* Add `AgentCapabilities.RequiresPayloadTrustVerification = 0x00010000`.
+* Add `ServerCapabilities.OffersPayloadTrustVerification = 0x00000080`.
+* Add `ServerToAgent.trust_chain_response = 12` carrying the new
+  `TrustChainResponse` message.
+* Add `ServerToAgent.signature = 13` carrying the per-message signature.
+* Add new top-level `TrustChainResponse` message containing the
+  certificate chain and an optional error message.
+
 ## v0.17.0
 
 * Fix typos in TLS version comments by @Kielek in https://github.com/open-telemetry/opamp-spec/pull/316

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,23 @@
 * Add `Message Attestation` section to specification.md describing an
   optional, end-to-end integrity mechanism for `ServerToAgent` messages
   based on X.509 certificate chains and a per-connection trust handshake.
-  Strict opt-in: existing OpAMP deployments are unaffected until both
-  Server and Agent opt in.
+  Strict opt-in at the wire level: existing OpAMP deployments are
+  unaffected until both Server and Agent opt in.
 * Add `AgentCapabilities.RequiresPayloadTrustVerification = 0x00010000`.
 * Add `ServerCapabilities.OffersPayloadTrustVerification = 0x00000080`.
-* Add `ServerToAgent.trust_chain_response = 12` carrying the new
-  `TrustChainResponse` message.
-* Add `ServerToAgent.signature = 13` carrying the per-message signature.
+* Add new top-level `SignedServerToAgent` envelope message containing
+  the marshalled `ServerToAgent` `payload`, a detached `signature` over
+  the payload bytes, and (on the first message of a connection) the
+  `trust_chain_response` carrying the signing certificate chain. The
+  envelope is used only when payload trust verification has been
+  negotiated; otherwise the Server keeps sending plain `ServerToAgent`
+  messages on the wire, byte-identical to upstream OpAMP.
 * Add new top-level `TrustChainResponse` message containing the
   certificate chain and an optional error message.
+* Reserve field numbers 12 and 13 on `ServerToAgent` (briefly used by
+  an earlier draft for inline trust-chain and signature fields; that
+  draft was superseded by the `SignedServerToAgent` envelope so the
+  numbers can never be reused).
 
 ## v0.17.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,13 +15,13 @@
   `trust_chain_response` carrying the signing certificate chain. The
   envelope is used only when payload trust verification has been
   negotiated; otherwise the Server keeps sending plain `ServerToAgent`
-  messages on the wire, byte-identical to upstream OpAMP.
+  messages on the wire, unchanged from the current protocol.
 * Add new top-level `TrustChainResponse` message containing the
   certificate chain and an optional error message.
-* Reserve field numbers 12 and 13 on `ServerToAgent` (briefly used by
-  an earlier draft for inline trust-chain and signature fields; that
-  draft was superseded by the `SignedServerToAgent` envelope so the
-  numbers can never be reused).
+* Reserve field numbers 14, 15, and 16 on `ServerToAgent` to keep them
+  non-overlapping with the field numbers used by `SignedServerToAgent`,
+  so the two messages cannot be accidentally misinterpreted for one
+  another by a decoder.
 
 ## v0.18.0
 

--- a/proto/opamp.proto
+++ b/proto/opamp.proto
@@ -351,17 +351,15 @@ message SignedServerToAgent {
     // and then unmarshals them into a ServerToAgent for normal processing.
     bytes payload = 1;
 
-    // Detached signature over the bytes of the payload field. MAY be empty
-    // on the first SignedServerToAgent of a connection: trust on the first
-    // message is established by validating the certificate chain carried in
-    // trust_chain_response against the Agent's pre-configured payload trust
-    // anchor. MUST be present and verifiable on every subsequent
-    // SignedServerToAgent.
+    // Detached signature over the bytes of the payload field. MUST be
+    // present and verifiable on every SignedServerToAgent, including the
+    // first. There is no exception for the first message.
     bytes signature = 2;
 
     // Sent only in the first SignedServerToAgent on a connection. Carries
-    // the signing certificate chain the Agent will use to verify signatures
-    // on subsequent messages. If the Agent set
+    // the signing certificate chain the Agent uses to validate the leaf
+    // certificate and verify signatures on all messages including this one.
+    // If the Agent set
     // RequiresPayloadTrustVerification but the first SignedServerToAgent
     // does not include a usable trust_chain_response, the Agent MUST
     // terminate the connection.

--- a/proto/opamp.proto
+++ b/proto/opamp.proto
@@ -329,6 +329,19 @@ message TrustChainResponse {
     // satisfy the trust chain request. If error_message is set, the Agent
     // MUST terminate the connection.
     string error_message = 2;
+
+    // PEM-encoded root CA certificate used as the payload trust anchor.
+    // Set only during Trust On First Use (TOFU) enrollment: the Server
+    // includes this when the Agent has advertised
+    // AgentCapabilities_AcceptsPayloadTrustAnchorTOFU and the Agent has no
+    // pre-configured trust anchor. The Agent MUST persist this certificate
+    // and use it as the payload trust anchor for all subsequent connections.
+    // The Agent MUST NOT update a previously persisted or operator-configured
+    // trust anchor — if the Agent already has a trust anchor this field MUST
+    // be ignored. To rotate a TOFU-enrolled anchor the operator deletes the
+    // persisted anchor file and restarts the Agent (out-of-band rotation).
+    // See the Trust On First Use (TOFU) section of the specification.
+    bytes tofu_trust_anchor = 3;
 }
 
 // SignedServerToAgent wraps a ServerToAgent message when the payload trust
@@ -860,6 +873,15 @@ enum AgentCapabilities {
     // the connection. See the Message Attestation section of the specification.
     // Status: [Development]
     AgentCapabilities_RequiresPayloadTrustVerification = 0x00010000;
+    // The Agent supports Trust On First Use (TOFU) enrollment for the payload
+    // trust anchor. When set alongside
+    // AgentCapabilities_RequiresPayloadTrustVerification it signals that the
+    // Agent has no pre-configured trust anchor and asks the Server to include
+    // the root CA in trust_chain_response.tofu_trust_anchor so the Agent can
+    // bootstrap and persist it. MUST NOT be set if the Agent already has a
+    // persisted or operator-configured trust anchor.
+    // Status: [Development]
+    AgentCapabilities_AcceptsPayloadTrustAnchorTOFU = 0x00020000;
     // Add new capabilities here, continuing with the least significant unused bit.
 }
 

--- a/proto/opamp.proto
+++ b/proto/opamp.proto
@@ -318,16 +318,12 @@ enum ServerCapabilities {
 // specification.
 // Status: [Development]
 message TrustChainResponse {
-    message Certificate {
-        // The certificate in DER format.
-        bytes der_data = 1;
-    }
-
-    // The certificate chain, ordered from the first intermediate certificate
-    // down to the signing leaf certificate. The root certificate is excluded;
-    // the Agent already possesses the root as its pre-configured payload
-    // trust anchor.
-    repeated Certificate certificate_chain = 1;
+    // PEM-encoded certificate chain, ordered from the first intermediate
+    // certificate down to the signing leaf certificate. The root certificate
+    // is excluded; the Agent already possesses the root as its pre-configured
+    // payload trust anchor. Multiple certificates are concatenated in a single
+    // PEM blob, consistent with the encoding used by TLSCertificate.
+    bytes certificate_chain = 1;
 
     // Human-readable error message indicating why the Server could not
     // satisfy the trust chain request. If error_message is set, the Agent

--- a/proto/opamp.proto
+++ b/proto/opamp.proto
@@ -243,6 +243,23 @@ message ServerToAgent {
     // A custom message sent from the Server to an Agent.
     // Status: [Development]
     CustomMessage custom_message = 11;
+
+    // Sent by the Server in its first ServerToAgent message in response to an
+    // Agent that has set the RequiresPayloadTrustVerification capability.
+    // Carries the signing certificate chain the Agent will use to verify
+    // subsequent ServerToAgent messages. If the Agent set
+    // RequiresPayloadTrustVerification but the first ServerToAgent does not
+    // include trust_chain_response, the Agent MUST terminate the connection.
+    // See the Message Attestation section of the specification.
+    // Status: [Development]
+    TrustChainResponse trust_chain_response = 12;
+
+    // The signature of this ServerToAgent message. The exact bytes that are
+    // signed and the verification procedure are defined in the
+    // Message Attestation section of the specification. Set only after the
+    // payload trust verification handshake has completed successfully.
+    // Status: [Development]
+    bytes signature = 13;
 }
 
 enum ServerToAgentFlags {
@@ -289,8 +306,36 @@ enum ServerCapabilities {
     // The Server can accept ConnectionSettingsRequest and respond with an offer.
     // Status: [Development]
     ServerCapabilities_AcceptsConnectionSettingsRequest = 0x00000040;
+    // The Server can respond to the payload trust verification handshake and
+    // sign every ServerToAgent message it sends after the handshake. See the
+    // Message Attestation section of the specification.
+    // Status: [Development]
+    ServerCapabilities_OffersPayloadTrustVerification = 0x00000080;
 
     // Add new capabilities here, continuing with the least significant unused bit.
+}
+
+// TrustChainResponse carries the signing certificate chain used by the Server
+// to sign subsequent ServerToAgent messages, as part of the payload trust
+// verification handshake. See the Message Attestation section of the
+// specification.
+// Status: [Development]
+message TrustChainResponse {
+    message Certificate {
+        // The certificate in DER format.
+        bytes der_data = 1;
+    }
+
+    // The certificate chain, ordered from the first intermediate certificate
+    // down to the signing leaf certificate. The root certificate is excluded;
+    // the Agent already possesses the root as its pre-configured payload
+    // trust anchor.
+    repeated Certificate certificate_chain = 1;
+
+    // Human-readable error message indicating why the Server could not
+    // satisfy the trust chain request. If error_message is set, the Agent
+    // MUST terminate the connection.
+    string error_message = 2;
 }
 
 // The OpAMPConnectionSettings message is a collection of fields which comprise an
@@ -781,6 +826,12 @@ enum AgentCapabilities {
     // The agent will report ConnectionSettingsOffers status via AgentToServer.connection_settings_status field.
     // Status: [Development]
     AgentCapabilities_ReportsConnectionSettingsStatus = 0x00008000;
+    // The Agent requires the payload trust verification handshake on connection
+    // and signature verification on every subsequent ServerToAgent message.
+    // If the Server does not offer this capability, the Agent MUST terminate
+    // the connection. See the Message Attestation section of the specification.
+    // Status: [Development]
+    AgentCapabilities_RequiresPayloadTrustVerification = 0x00010000;
     // Add new capabilities here, continuing with the least significant unused bit.
 }
 

--- a/proto/opamp.proto
+++ b/proto/opamp.proto
@@ -244,22 +244,14 @@ message ServerToAgent {
     // Status: [Development]
     CustomMessage custom_message = 11;
 
-    // Sent by the Server in its first ServerToAgent message in response to an
-    // Agent that has set the RequiresPayloadTrustVerification capability.
-    // Carries the signing certificate chain the Agent will use to verify
-    // subsequent ServerToAgent messages. If the Agent set
-    // RequiresPayloadTrustVerification but the first ServerToAgent does not
-    // include trust_chain_response, the Agent MUST terminate the connection.
-    // See the Message Attestation section of the specification.
-    // Status: [Development]
-    TrustChainResponse trust_chain_response = 12;
-
-    // The signature of this ServerToAgent message. The exact bytes that are
-    // signed and the verification procedure are defined in the
-    // Message Attestation section of the specification. Set only after the
-    // payload trust verification handshake has completed successfully.
-    // Status: [Development]
-    bytes signature = 13;
+    // Field numbers 12 and 13 were briefly assigned to inline payload
+    // trust verification metadata (trust_chain_response and signature)
+    // in an earlier draft of the Message Attestation spec. The design
+    // moved that metadata onto a separate envelope message
+    // (SignedServerToAgent) to enable detached signing. The field
+    // numbers are reserved here to prevent accidental reuse.
+    reserved 12, 13;
+    reserved "trust_chain_response", "signature";
 }
 
 enum ServerToAgentFlags {
@@ -336,6 +328,43 @@ message TrustChainResponse {
     // satisfy the trust chain request. If error_message is set, the Agent
     // MUST terminate the connection.
     string error_message = 2;
+}
+
+// SignedServerToAgent wraps a ServerToAgent message when the payload trust
+// verification handshake has been negotiated between Server and Agent. When
+// both AgentCapabilities_RequiresPayloadTrustVerification (set by the Agent)
+// and ServerCapabilities_OffersPayloadTrustVerification (set by the Server)
+// are advertised, every Server-to-Agent message on the connection is wrapped
+// in SignedServerToAgent.
+//
+// The signature is computed and verified over the bytes of the payload field
+// exactly as they appear on the wire (a "detached" signature). This avoids
+// any dependency on canonical protobuf encoding, which is not guaranteed
+// across protobuf library versions, schema changes, or build flags.
+//
+// See the Message Attestation section of the specification.
+// Status: [Development]
+message SignedServerToAgent {
+    // Serialised bytes of a ServerToAgent message. The Agent verifies the
+    // detached signature over these exact bytes, without re-marshalling,
+    // and then unmarshals them into a ServerToAgent for normal processing.
+    bytes payload = 1;
+
+    // Detached signature over the bytes of the payload field. MAY be empty
+    // on the first SignedServerToAgent of a connection: trust on the first
+    // message is established by validating the certificate chain carried in
+    // trust_chain_response against the Agent's pre-configured payload trust
+    // anchor. MUST be present and verifiable on every subsequent
+    // SignedServerToAgent.
+    bytes signature = 2;
+
+    // Sent only in the first SignedServerToAgent on a connection. Carries
+    // the signing certificate chain the Agent will use to verify signatures
+    // on subsequent messages. If the Agent set
+    // RequiresPayloadTrustVerification but the first SignedServerToAgent
+    // does not include a usable trust_chain_response, the Agent MUST
+    // terminate the connection.
+    TrustChainResponse trust_chain_response = 3;
 }
 
 // The OpAMPConnectionSettings message is a collection of fields which comprise an

--- a/proto/opamp.proto
+++ b/proto/opamp.proto
@@ -249,10 +249,14 @@ message ServerToAgent {
     // trust verification metadata (trust_chain_response and signature)
     // in an earlier draft of the Message Attestation spec. The design
     // moved that metadata onto a separate envelope message
-    // (SignedServerToAgent) to enable detached signing. The field
-    // numbers are reserved here to prevent accidental reuse.
-    reserved 12, 13;
-    reserved "trust_chain_response", "signature";
+    // (SignedServerToAgent) to enable detached signing. Field numbers
+    // 14–16 are assigned to SignedServerToAgent.payload, .signature,
+    // and .trust_chain_response respectively, so that the two messages
+    // have non-overlapping field numbers and cannot be accidentally
+    // misinterpreted by a parser expecting the other type. All six
+    // field numbers are reserved here to prevent reuse on ServerToAgent.
+    reserved 12, 13, 14, 15, 16;
+    reserved "trust_chain_response", "signature", "payload";
 }
 
 enum ServerToAgentFlags {
@@ -349,12 +353,12 @@ message SignedServerToAgent {
     // Serialised bytes of a ServerToAgent message. The Agent verifies the
     // detached signature over these exact bytes, without re-marshalling,
     // and then unmarshals them into a ServerToAgent for normal processing.
-    bytes payload = 1;
+    bytes payload = 14;
 
     // Detached signature over the bytes of the payload field. MUST be
     // present and verifiable on every SignedServerToAgent, including the
     // first. There is no exception for the first message.
-    bytes signature = 2;
+    bytes signature = 15;
 
     // Sent only in the first SignedServerToAgent on a connection. Carries
     // the signing certificate chain the Agent uses to validate the leaf
@@ -363,7 +367,7 @@ message SignedServerToAgent {
     // RequiresPayloadTrustVerification but the first SignedServerToAgent
     // does not include a usable trust_chain_response, the Agent MUST
     // terminate the connection.
-    TrustChainResponse trust_chain_response = 3;
+    TrustChainResponse trust_chain_response = 16;
 }
 
 // The OpAMPConnectionSettings message is a collection of fields which comprise an

--- a/proto/opamp.proto
+++ b/proto/opamp.proto
@@ -369,10 +369,18 @@ message SignedServerToAgent {
     // first. There is no exception for the first message.
     bytes signature = 15;
 
-    // Sent only in the first SignedServerToAgent on a connection. Carries
-    // the signing certificate chain the Agent uses to validate the leaf
-    // certificate and verify signatures on all messages including this one.
-    // If the Agent set
+    // Sent in the first SignedServerToAgent on a connection, and again
+    // whenever the signing certificate chain changes (signing certificate
+    // rotation). Carries the signing certificate chain the Agent uses to
+    // validate the leaf certificate and verify signatures. The root
+    // (payload trust anchor) never changes; only the chain to it does.
+    // When trust_chain_response carries a chain that differs from the one
+    // the Agent currently has pinned, the Agent MUST validate it against
+    // its pre-configured trust anchor and re-pin the resulting leaf; a
+    // chain identical to the pinned one is a no-op. This lets a
+    // mid-connection rotation avoid dropping the connection. The HTTP
+    // transport MAY re-send the chain on every response, so the Agent MUST
+    // treat an unchanged chain as a no-op. If the Agent set
     // RequiresPayloadTrustVerification but the first SignedServerToAgent
     // does not include a usable trust_chain_response, the Agent MUST
     // terminate the connection.

--- a/proto/opamp.proto
+++ b/proto/opamp.proto
@@ -245,18 +245,13 @@ message ServerToAgent {
     // Status: [Development]
     CustomMessage custom_message = 11;
 
-    // Field numbers 12 and 13 were briefly assigned to inline payload
-    // trust verification metadata (trust_chain_response and signature)
-    // in an earlier draft of the Message Attestation spec. The design
-    // moved that metadata onto a separate envelope message
-    // (SignedServerToAgent) to enable detached signing. Field numbers
-    // 14–16 are assigned to SignedServerToAgent.payload, .signature,
-    // and .trust_chain_response respectively, so that the two messages
-    // have non-overlapping field numbers and cannot be accidentally
-    // misinterpreted by a parser expecting the other type. All six
-    // field numbers are reserved here to prevent reuse on ServerToAgent.
-    reserved 12, 13, 14, 15, 16;
-    reserved "trust_chain_response", "signature", "payload";
+    // Field numbers 14, 15, and 16 are reserved on ServerToAgent because
+    // they are used by SignedServerToAgent, the envelope message that
+    // carries a serialised ServerToAgent in its payload field. Keeping the
+    // field numbers of the two messages non-overlapping ensures that if the
+    // bytes of one are ever decoded as the other, the mismatched fields are
+    // seen as unknown fields and ignored rather than silently misinterpreted.
+    reserved 14, 15, 16;
 }
 
 enum ServerToAgentFlags {

--- a/specification.md
+++ b/specification.md
@@ -3571,9 +3571,6 @@ Agent by default. The capabilities should be opt-in by the user.
 
 Any executable code that is part of a package should be signed
 to prevent a compromised Server from delivering malicious code to the Agent.
-For end-to-end integrity of OpAMP messages themselves (including remote
-configuration offers, package offers, and Server-issued commands), see the
-[Message Attestation](#message-attestation) section.
 We recommend the following:
 
 * Any downloadable executable code (e.g. executable packages)
@@ -3592,6 +3589,10 @@ We recommend the following:
   code that it runs as external processes) at the minimum possible privilege to
   prevent the code from accessing sensitive files or perform high privilege
   operations. The Agent should not run downloaded code as root user.
+
+For end-to-end integrity of OpAMP messages themselves (including remote
+configuration offers, package offers, and Server-issued commands), see the
+[Message Attestation](#message-attestation) section.
 
 ## Message Attestation
 
@@ -3707,10 +3708,11 @@ sending plain `ServerToAgent` messages, and the Agent keeps parsing
 them as such. Implementations that do not implement Message Attestation
 therefore see no wire-format change at all.
 
-A Server may advertise `OffersPayloadTrustVerification` and only wrap
-its outbound messages in `SignedServerToAgent` on connections from
-Agents that have set `RequiresPayloadTrustVerification` — there is no
-per-message cost for advertising the capability to non-opted-in Agents.
+A Server SHOULD only advertise `OffersPayloadTrustVerification` to
+Agents that have set `RequiresPayloadTrustVerification`, as advertising
+to non-opted-in Agents adds unnecessary bits to the capabilities field.
+A Server MUST only wrap its outbound messages in `SignedServerToAgent`
+on connections from Agents that have set `RequiresPayloadTrustVerification`.
 
 ### Capability Negotiation
 
@@ -3718,7 +3720,7 @@ per-message cost for advertising the capability to non-opted-in Agents.
 | --- | --- | --- |
 | No | No | Plain OpAMP. The Server sends `ServerToAgent` messages on the wire. Today's behaviour. |
 | No | Yes | Plain OpAMP. The Server is capable of signing but the Agent has not opted in, so the Server sends `ServerToAgent` messages on the wire (not `SignedServerToAgent`). |
-| Yes | No | The Server does not send `SignedServerToAgent`. The Agent receives a plain `ServerToAgent` where it expected a `SignedServerToAgent` envelope, and MUST terminate the connection. |
+| Yes | No | The Server does not send `SignedServerToAgent`. The Agent receives a plain `ServerToAgent` where it expected a `SignedServerToAgent` envelope. The Agent MUST treat this as a failure as described in [Failure Modes](#failure-modes). |
 | Yes | Yes | Every Server-to-Agent message on the connection is wrapped in `SignedServerToAgent`. Handshake on the first message (carries `trust_chain_response`); per-message detached signatures thereafter. Specified in the remainder of this section. |
 
 ### Connection-Time Handshake
@@ -3772,8 +3774,12 @@ first such envelope carries the signing certificate chain in
      `id-kp-codeSigning` EKU, failed name/policy constraints, or
      revocation — the Agent MUST terminate the connection.
    * On successful validation, the Agent stores the validated leaf
-     certificate (or its public key) for the duration of the
-     connection.
+     certificate (or its public key) for the duration of the session.
+     For WebSocket transport the session ends when the connection closes.
+     For HTTP transport the session persists across polling requests and
+     ends when the Agent restarts or explicitly reconnects. On
+     reconnection, the handshake is repeated and the Server presents a
+     fresh certificate chain.
    * The Agent MUST verify `signature` over the `payload` bytes using
      the public key of the validated leaf certificate. If `signature`
      is absent or verification fails, the Agent MUST terminate the
@@ -3786,13 +3792,13 @@ first such envelope carries the signing certificate chain in
 ```protobuf
 message SignedServerToAgent {
     // Serialised bytes of a ServerToAgent message.
-    bytes payload = 1;
+    bytes payload = 14;
 
     // Detached signature over the bytes of the payload field.
-    bytes signature = 2;
+    bytes signature = 15;
 
     // Sent only in the first SignedServerToAgent on a connection.
-    TrustChainResponse trust_chain_response = 3;
+    TrustChainResponse trust_chain_response = 16;
 }
 ```
 
@@ -3934,9 +3940,11 @@ they evolve.
 The signing leaf certificate MUST:
 
 * Include the Extended Key Usage extension with `id-kp-codeSigning`
-  (`1.3.6.1.5.5.7.3.3`) in its list of allowed usages. This prevents a
-  certificate intended for TLS server authentication from being used
-  to sign OpAMP messages.
+  (`1.3.6.1.5.5.7.3.3`) in its list of allowed usages. TLS server
+  certificates carry `id-kp-serverAuth` instead; because the Agent
+  requires `id-kp-codeSigning` during chain validation, a TLS
+  certificate will fail the EKU check and cannot be repurposed as a
+  signing certificate.
 * Be within its validity window
   (`notBefore <= currentTime < notAfter`) at every verification.
 
@@ -3952,13 +3960,14 @@ short-lived certificates as an alternative to active revocation.
 
 ### Failure Modes
 
-Every failure listed below MUST cause the Agent to terminate the OpAMP
-connection. The Agent SHOULD reconnect using exponential backoff consistent
-with normal OpAMP reconnection behaviour; on reconnection the Server presents
-a (potentially rotated) chain on the new handshake. Because these failures
-are detected locally by the Agent, no dedicated error-response field is
-required — the Agent terminates the connection without waiting for a
-`ServerToAgent.error_response`.
+Every failure listed below MUST cause the Agent to terminate the current
+exchange without processing the received payload. For WebSocket transport,
+the Agent closes the WebSocket connection. For HTTP transport, the Agent
+discards the response body. In both cases, the Agent SHOULD reconnect using
+exponential backoff consistent with normal OpAMP reconnection behaviour; on
+reconnection the Server presents a (potentially rotated) chain on the new
+handshake. Because these failures are detected locally by the Agent, no
+dedicated error-response field is required.
 
 | Failure | When detected |
 | --- | --- |

--- a/specification.md
+++ b/specification.md
@@ -3665,7 +3665,7 @@ The Server is independently configured with a signing key and its
 corresponding certificate chain that validates back to the payload trust
 anchor.
 
-The payload trust anchor is NEVER pushed by the Server. In particular,
+The payload trust anchor is NEVER sent from the Server to the Agent. In particular,
 no field of any `ServerToAgent` message — including
 [`OpAMPConnectionSettings`](#opampconnectionsettings) — may be used to
 update or replace the Agent's payload trust anchor. This is a deliberate
@@ -3764,12 +3764,15 @@ first such envelope carries the signing certificate chain in
      `SignedServerToAgent`.)
    * If `trust_chain_response.error_message` is non-empty, the Agent
      MUST terminate the connection.
-   * Otherwise the Agent performs standard X.509 path validation of
-     `certificate_chain` using the pre-configured payload trust anchor
-     as the trust root. If validation fails — for any reason, including
-     expired leaf, expired intermediate, unknown issuer, missing
-     `id-kp-codeSigning` Extended Key Usage on the leaf, or revocation
-     — the Agent MUST terminate the connection.
+   * Otherwise the Agent MUST perform X.509 certification path
+     validation as defined in [RFC 5280 §6](https://datatracker.ietf.org/doc/html/rfc5280#section-6),
+     using the pre-configured payload trust anchor as the sole trust
+     anchor, `certificate_chain` as the intermediate and leaf
+     certificates, and `id-kp-codeSigning` (`1.3.6.1.5.5.7.3.3`) in the
+     acceptable EKU set. If path validation fails for any reason —
+     including expired certificate, unknown issuer, missing
+     `id-kp-codeSigning` EKU, failed name/policy constraints, or
+     revocation — the Agent MUST terminate the connection.
    * On successful validation, the Agent stores the validated leaf
      certificate (or its public key) for the duration of the
      connection and uses it to verify every subsequent

--- a/specification.md
+++ b/specification.md
@@ -3743,10 +3743,9 @@ first such envelope carries the signing certificate chain in
      satisfy the trust chain request (for example, because its signing
      key is unavailable). When `error_message` is non-empty,
      `certificate_chain` SHOULD be empty.
-   * MAY leave `signature` empty on this first envelope. Trust on the
-     first message is established by chain validation against the
-     pre-configured trust anchor, not by a self-signature. Every
-     subsequent `SignedServerToAgent` MUST carry a valid signature.
+   * MUST set `signature` to a valid detached signature over the
+     `payload` bytes on this first envelope and on every subsequent
+     envelope. There is no exception for the first message.
    * Sets `payload` to the marshalled bytes of a `ServerToAgent`
      message containing whatever the Server would have sent had
      signing not been negotiated (for example, an empty `ServerToAgent`
@@ -3774,8 +3773,11 @@ first such envelope carries the signing certificate chain in
      revocation — the Agent MUST terminate the connection.
    * On successful validation, the Agent stores the validated leaf
      certificate (or its public key) for the duration of the
-     connection and uses it to verify every subsequent
-     `SignedServerToAgent`.
+     connection.
+   * The Agent MUST verify `signature` over the `payload` bytes using
+     the public key of the validated leaf certificate. If `signature`
+     is absent or verification fails, the Agent MUST terminate the
+     connection.
    * The Agent then unmarshals the `payload` bytes into a
      `ServerToAgent` and processes it normally.
 
@@ -3804,17 +3806,18 @@ these bytes into a `ServerToAgent` for normal processing.
 
 ##### SignedServerToAgent.signature
 
-Detached signature over the bytes of `payload`. MAY be empty on the
-first `SignedServerToAgent` of a connection — chain validation against
-the pre-configured trust anchor establishes initial trust. MUST be
-present and verifiable on every subsequent message.
+Detached signature over the bytes of `payload`. MUST be present and
+verifiable on every `SignedServerToAgent`, including the first. There
+is no exception for the first message — the Server signs the payload
+immediately using the signing key whose certificate chain is carried in
+`trust_chain_response`.
 
 ##### SignedServerToAgent.trust_chain_response
 
 Sent only in the first `SignedServerToAgent` on a connection. Carries
-the signing certificate chain the Agent will use to verify signatures
-on subsequent messages. See
-[TrustChainResponse Message](#trustchainresponse-message).
+the signing certificate chain the Agent uses to validate the leaf
+certificate and verify signatures on all messages including this one.
+See [TrustChainResponse Message](#trustchainresponse-message).
 
 #### TrustChainResponse Message
 
@@ -3887,8 +3890,7 @@ The Server produces a `SignedServerToAgent` as follows:
    from step 3. On the first message, also set `trust_chain_response`.
 5. Marshal and send the `SignedServerToAgent`.
 
-The Agent verifies a received `SignedServerToAgent` (after the first)
-as follows:
+The Agent verifies a received `SignedServerToAgent` as follows:
 
 1. Parse the wire bytes as a `SignedServerToAgent`. Retain the
    `payload` field's raw bytes — these are the bytes the signature
@@ -3964,8 +3966,8 @@ required — the Agent terminates the connection without waiting for a
 | First `SignedServerToAgent` does not include `trust_chain_response`. | First message. |
 | `trust_chain_response.error_message` is non-empty. | First message. |
 | Certificate chain fails X.509 path validation (expired certificate, unknown issuer, missing `id-kp-codeSigning` EKU, revoked certificate, etc.). | First message. |
-| In-session `SignedServerToAgent` lacks `signature`. | Any subsequent message. |
-| In-session `signature` does not verify against the stored leaf certificate over the received `payload` bytes. | Any subsequent message. |
+| `SignedServerToAgent` lacks `signature`. | Every message. |
+| `signature` does not verify against the stored leaf certificate over the received `payload` bytes. | Every message. |
 | Stored leaf certificate's validity window has expired since the handshake. | The next verification after expiry. |
 
 ### Out of Scope

--- a/specification.md
+++ b/specification.md
@@ -54,8 +54,6 @@ Status: [Beta]
       - [ServerToAgent.command](#servertoagentcommand)
       - [ServerToAgent.custom_capabilities](#servertoagentcustom_capabilities)
       - [ServerToAgent.custom_message](#servertoagentcustom_message)
-      - [ServerToAgent.trust_chain_response](#servertoagenttrust_chain_response)
-      - [ServerToAgent.signature](#servertoagentsignature)
     + [ServerErrorResponse Message](#servererrorresponse-message)
       - [ServerErrorResponse.type](#servererrorresponsetype)
       - [ServerErrorResponse.error_message](#servererrorresponseerror_message)
@@ -233,6 +231,10 @@ Status: [Beta]
   * [Opt-in and Backwards Compatibility](#opt-in-and-backwards-compatibility)
   * [Capability Negotiation](#capability-negotiation)
   * [Connection-Time Handshake](#connection-time-handshake)
+    + [SignedServerToAgent Message](#signedservertoagent-message)
+      - [SignedServerToAgent.payload](#signedservertoagentpayload)
+      - [SignedServerToAgent.signature](#signedservertoagentsignature)
+      - [SignedServerToAgent.trust_chain_response](#signedservertoagenttrust_chain_response)
     + [TrustChainResponse Message](#trustchainresponse-message)
       - [TrustChainResponse.certificate_chain](#trustchainresponsecertificate_chain)
       - [TrustChainResponse.error_message](#trustchainresponseerror_message)
@@ -988,32 +990,6 @@ Status: [Development]
 A custom message sent from the Server to an Agent.
 
 See [CustomMessage](#custommessage) message for details.
-
-##### ServerToAgent.trust_chain_response
-
-Status: [Development]
-
-Sent by the Server in its first `ServerToAgent` message in response to an
-Agent that has set the
-[`RequiresPayloadTrustVerification`](#agenttoservercapabilities) capability. The
-Agent uses the contained certificate chain to verify the signature on
-every subsequent `ServerToAgent` message.
-
-See the [Message Attestation](#message-attestation) section for the full
-handshake and verification procedure, and the
-[`TrustChainResponse`](#trustchainresponse-message) message for the field
-layout.
-
-##### ServerToAgent.signature
-
-Status: [Development]
-
-The signature of this `ServerToAgent` message. Set by the Server only
-after a successful payload trust verification handshake, and verified by
-the Agent against the leaf certificate established by that handshake.
-
-The exact bytes that are signed and the verification procedure are
-defined in the [Message Attestation](#message-attestation) section.
 
 #### ServerErrorResponse Message
 
@@ -3712,52 +3688,69 @@ specification until both sides opt in.**
 
 The new capability bits are additions to a 64-bit bitmask.
 Implementations that do not recognise the new bits will simply not match
-them and will behave exactly as today. The new `ServerToAgent` fields
-(`trust_chain_response` and `signature`) are proto3 scalar/message
-additions and are ignored by implementations that predate them.
+them and will behave exactly as today.
 
-A Server may advertise `OffersPayloadTrustVerification` and only sign
-`ServerToAgent` messages on connections from Agents that have set
-`RequiresPayloadTrustVerification` — there is no per-message cost for
-advertising the capability to non-opted-in Agents.
+The `SignedServerToAgent` envelope is sent **only** when the negotiation
+succeeds. For connections where Message Attestation is not negotiated,
+the wire format is byte-identical to upstream OpAMP — the Server keeps
+sending plain `ServerToAgent` messages, and the Agent keeps parsing
+them as such. Implementations that do not implement Message Attestation
+therefore see no wire-format change at all.
+
+A Server may advertise `OffersPayloadTrustVerification` and only wrap
+its outbound messages in `SignedServerToAgent` on connections from
+Agents that have set `RequiresPayloadTrustVerification` — there is no
+per-message cost for advertising the capability to non-opted-in Agents.
 
 ### Capability Negotiation
 
 | Agent `Requires` | Server `Offers` | Behaviour |
 | --- | --- | --- |
-| No | No | Plain OpAMP. Today's behaviour. |
-| No | Yes | Plain OpAMP. The Server is capable of signing but the Agent has not opted in, so no `trust_chain_response` is sent and no signatures are emitted. |
-| Yes | No | The Server's first `ServerToAgent` lacks `trust_chain_response`. The Agent MUST terminate the connection. |
-| Yes | Yes | Handshake on the first `ServerToAgent`; per-message signatures thereafter. Specified in the remainder of this section. |
+| No | No | Plain OpAMP. The Server sends `ServerToAgent` messages on the wire. Today's behaviour. |
+| No | Yes | Plain OpAMP. The Server is capable of signing but the Agent has not opted in, so the Server sends `ServerToAgent` messages on the wire (not `SignedServerToAgent`). |
+| Yes | No | The Server does not send `SignedServerToAgent`. The Agent receives a plain `ServerToAgent` where it expected a `SignedServerToAgent` envelope, and MUST terminate the connection. |
+| Yes | Yes | Every Server-to-Agent message on the connection is wrapped in `SignedServerToAgent`. Handshake on the first message (carries `trust_chain_response`); per-message detached signatures thereafter. Specified in the remainder of this section. |
 
 ### Connection-Time Handshake
 
 When the Agent has set `RequiresPayloadTrustVerification` and the Server
-has set `OffersPayloadTrustVerification`, the first `ServerToAgent`
-message exchanged on the connection MUST carry a
-[`trust_chain_response`](#servertoagenttrust_chain_response).
+has set `OffersPayloadTrustVerification`, every Server-to-Agent message
+on the connection is wrapped in a `SignedServerToAgent` envelope. The
+first such envelope carries the signing certificate chain in
+`trust_chain_response`.
 
 1. The Agent's first `AgentToServer` message sets the
    `RequiresPayloadTrustVerification` bit in `capabilities`.
 
-2. The Server's first `ServerToAgent` message:
-   * MUST set `trust_chain_response.certificate_chain` to the ordered
-     list of certificates from the first intermediate down to the
-     signing leaf certificate. The root certificate (the Agent's
-     pre-configured payload trust anchor) MUST NOT be included in this
-     chain.
+2. The Server, on receiving the Agent's first message and recognising
+   the capability:
+   * Sends its first `SignedServerToAgent` containing
+     `trust_chain_response.certificate_chain` ordered from the first
+     intermediate down to the signing leaf certificate. The root
+     certificate (the Agent's pre-configured payload trust anchor)
+     MUST NOT be included in this chain.
    * MAY set `trust_chain_response.error_message` if the Server cannot
      satisfy the trust chain request (for example, because its signing
      key is unavailable). When `error_message` is non-empty,
      `certificate_chain` SHOULD be empty.
-   * MAY omit the [`signature`](#servertoagentsignature) field on this
-     first message. Trust on the first message is established by chain
-     validation against the pre-configured trust anchor, not by a
-     self-signature. Every subsequent `ServerToAgent` MUST be signed.
+   * MAY leave `signature` empty on this first envelope. Trust on the
+     first message is established by chain validation against the
+     pre-configured trust anchor, not by a self-signature. Every
+     subsequent `SignedServerToAgent` MUST carry a valid signature.
+   * Sets `payload` to the marshalled bytes of a `ServerToAgent`
+     message containing whatever the Server would have sent had
+     signing not been negotiated (for example, an empty `ServerToAgent`
+     acknowledging the Agent's status report, or a `ServerToAgent`
+     carrying initial `remote_config`).
 
-3. The Agent receives the Server's first `ServerToAgent` and:
-   * If `trust_chain_response` is unset, the Agent MUST terminate the
-     connection.
+3. The Agent receives the Server's first envelope and:
+   * Parses the bytes on the wire as `SignedServerToAgent`. If the
+     bytes cannot be parsed as `SignedServerToAgent`, or
+     `trust_chain_response` is unset, the Agent MUST terminate the
+     connection. (This is also how the Agent detects a Server that
+     does not support Message Attestation: such a Server would send a
+     plain `ServerToAgent`, which does not parse as
+     `SignedServerToAgent`.)
    * If `trust_chain_response.error_message` is non-empty, the Agent
      MUST terminate the connection.
    * Otherwise the Agent performs standard X.509 path validation of
@@ -3767,8 +3760,48 @@ message exchanged on the connection MUST carry a
      `id-kp-codeSigning` Extended Key Usage on the leaf, or revocation
      — the Agent MUST terminate the connection.
    * On successful validation, the Agent stores the validated leaf
-     certificate (or its public key) for the duration of the connection
-     and uses it to verify every subsequent `ServerToAgent` message.
+     certificate (or its public key) for the duration of the
+     connection and uses it to verify every subsequent
+     `SignedServerToAgent`.
+   * The Agent then unmarshals the `payload` bytes into a
+     `ServerToAgent` and processes it normally.
+
+#### SignedServerToAgent Message
+
+```protobuf
+message SignedServerToAgent {
+    // Serialised bytes of a ServerToAgent message.
+    bytes payload = 1;
+
+    // Detached signature over the bytes of the payload field.
+    bytes signature = 2;
+
+    // Sent only in the first SignedServerToAgent on a connection.
+    TrustChainResponse trust_chain_response = 3;
+}
+```
+
+##### SignedServerToAgent.payload
+
+Marshalled bytes of an inner `ServerToAgent` message. The Server
+marshals the inner `ServerToAgent` once and places the resulting bytes
+here. The signature in `signature` covers these exact bytes; the Agent
+verifies the signature without re-marshalling, and then unmarshals
+these bytes into a `ServerToAgent` for normal processing.
+
+##### SignedServerToAgent.signature
+
+Detached signature over the bytes of `payload`. MAY be empty on the
+first `SignedServerToAgent` of a connection — chain validation against
+the pre-configured trust anchor establishes initial trust. MUST be
+present and verifiable on every subsequent message.
+
+##### SignedServerToAgent.trust_chain_response
+
+Sent only in the first `SignedServerToAgent` on a connection. Carries
+the signing certificate chain the Agent will use to verify signatures
+on subsequent messages. See
+[TrustChainResponse Message](#trustchainresponse-message).
 
 #### TrustChainResponse Message
 
@@ -3807,38 +3840,59 @@ SHOULD be empty and the Agent MUST terminate the connection.
 
 ### In-Session Signature Verification
 
-For every `ServerToAgent` message after the first, the Server MUST set
-the `signature` field to a signature over the message bytes, computed as
-follows:
+Signatures are computed and verified **over the bytes of the inner
+`ServerToAgent` exactly as they appear on the wire in
+`SignedServerToAgent.payload`** — a "detached" signature scheme. The
+Server marshals each inner `ServerToAgent` once, signs those bytes,
+and places them into `payload`; the Agent verifies the signature over
+the received `payload` bytes without re-marshalling.
 
-1. Construct the `ServerToAgent` message with all required fields set
-   except `signature`, which is left empty (zero-length).
-2. Serialise the message using deterministic Protocol Buffers encoding
-   (for example, Go's `proto.MarshalOptions{Deterministic: true}` or
-   the equivalent in other implementations).
-3. Sign the resulting byte string with the Server's signing private
-   key, using the signature algorithm declared by the leaf
+> **Why detached signing?** Protocol Buffers does not guarantee a
+> canonical wire-format encoding, even with deterministic-output
+> options enabled. The serializer can produce different output across
+> protobuf library versions, schema changes, and build flags (see the
+> upstream guidance at
+> <https://protobuf.dev/programming-guides/serialization-not-canonical/>).
+> Any signature scheme that requires the receiver to re-marshal a
+> parsed message and reproduce the signed bytes would therefore be
+> fragile across implementations and versions. Detached signing over
+> the wire bytes side-steps the problem entirely: the signed bytes are
+> the wire bytes, and they survive any number of round-trips through
+> different protobuf libraries.
+
+The Server produces a `SignedServerToAgent` as follows:
+
+1. Construct the inner `ServerToAgent` message normally.
+2. Marshal the inner message to bytes using any conformant Protocol
+   Buffers encoder. (No special "deterministic" option is required;
+   the only bytes that matter are the ones placed on the wire.)
+3. Compute a signature over those bytes using the Server's signing
+   private key and the signature algorithm declared by the leaf
    certificate's `signatureAlgorithm` field.
-4. Set `signature` to the resulting signature bytes.
+4. Construct the outer `SignedServerToAgent` with `payload` set to the
+   marshalled bytes from step 2 and `signature` set to the signature
+   from step 3. On the first message, also set `trust_chain_response`.
+5. Marshal and send the `SignedServerToAgent`.
 
-The Agent verifies a received `ServerToAgent` message as follows:
+The Agent verifies a received `SignedServerToAgent` (after the first)
+as follows:
 
-1. Extract the `signature` field. If `signature` is empty or absent on
-   any message after the handshake, the Agent MUST terminate the
+1. Parse the wire bytes as a `SignedServerToAgent`. Retain the
+   `payload` field's raw bytes — these are the bytes the signature
+   covers.
+2. If `signature` is empty or absent, the Agent MUST terminate the
    connection.
-2. Construct a copy of the received message with `signature` cleared
-   (set to empty bytes).
-3. Serialise the copy using deterministic Protocol Buffers encoding.
-4. Verify the extracted `signature` against the resulting byte string
-   using the public key of the leaf certificate established during the
-   handshake, and the signature algorithm declared by the leaf
-   certificate's `signatureAlgorithm`.
-5. If verification fails, the Agent MUST terminate the connection.
+3. Verify `signature` over the `payload` bytes using the public key of
+   the leaf certificate established during the handshake, and the
+   signature algorithm declared by the leaf certificate's
+   `signatureAlgorithm`.
+4. If verification fails, the Agent MUST terminate the connection.
+5. On success, unmarshal the `payload` bytes into a `ServerToAgent`
+   and process it normally.
 
-Implementations MUST use deterministic Protocol Buffers encoding for
-both signing and verification. Cross-language implementations must
-produce byte-identical canonical serialisations for the signed payload
-to interoperate.
+Because the signature is detached, the Agent never needs to re-marshal
+the inner `ServerToAgent`. This eliminates any dependency on canonical
+serialisation between implementations.
 
 ### Algorithm
 
@@ -3889,12 +3943,12 @@ connection. Recovery is by reconnection; the Server presents a
 
 | Failure | When detected |
 | --- | --- |
-| Agent set `RequiresPayloadTrustVerification` but the Server did not set `OffersPayloadTrustVerification`. | First `ServerToAgent` (capability bits visible at that time). |
-| Server's first `ServerToAgent` does not include `trust_chain_response`. | First `ServerToAgent`. |
-| `trust_chain_response.error_message` is non-empty. | First `ServerToAgent`. |
-| Certificate chain fails X.509 path validation (expired certificate, unknown issuer, missing `id-kp-codeSigning` EKU, revoked certificate, etc.). | First `ServerToAgent`. |
-| In-session `ServerToAgent` message lacks `signature`. | Any subsequent `ServerToAgent`. |
-| In-session `signature` does not verify against the stored leaf certificate. | Any subsequent `ServerToAgent`. |
+| Agent set `RequiresPayloadTrustVerification` but the Server did not send a `SignedServerToAgent` envelope (typically because the Server does not support the capability and sent a plain `ServerToAgent`). | First message received from the Server. |
+| First `SignedServerToAgent` does not include `trust_chain_response`. | First message. |
+| `trust_chain_response.error_message` is non-empty. | First message. |
+| Certificate chain fails X.509 path validation (expired certificate, unknown issuer, missing `id-kp-codeSigning` EKU, revoked certificate, etc.). | First message. |
+| In-session `SignedServerToAgent` lacks `signature`. | Any subsequent message. |
+| In-session `signature` does not verify against the stored leaf certificate over the received `payload` bytes. | Any subsequent message. |
 | Stored leaf certificate's validity window has expired since the handshake. | The next verification after expiry. |
 
 ### Out of Scope

--- a/specification.md
+++ b/specification.md
@@ -3652,8 +3652,8 @@ Message Attestation does **not** address:
 The Agent is pre-configured with a single root CA certificate, referred
 to in this section as the _payload trust anchor_. This certificate is
 operator-managed and is supplied to the Agent through
-implementation-specific configuration (for example, a file path in the
-Agent's configuration). The payload trust anchor MUST NOT carry the `id-kp-serverAuth`
+implementation-specific configuration (for example, a file path or an
+inline PEM value in the Agent's configuration). The payload trust anchor MUST NOT carry the `id-kp-serverAuth`
 Extended Key Usage, ensuring it cannot double as a TLS CA certificate.
 Operators MAY root both the TLS chain and the signing chain from the
 same root CA, provided the signing intermediate and leaf certificates
@@ -3665,12 +3665,15 @@ requirement for a separate root CA.
 The Server is independently configured with a signing key and its
 corresponding certificate chain rooted in the payload trust anchor.
 
-The payload trust anchor is NEVER sent from the Server to the Agent. In particular,
-no field of any `ServerToAgent` message — including
+The payload trust anchor is NEVER sent from the Server to the Agent, with one
+exception: Agents that have not yet enrolled a trust anchor MAY opt in to Trust
+On First Use (TOFU) enrollment, described in
+[Trust On First Use (TOFU)](#trust-on-first-use-tofu).
+In all other cases — including when a TOFU anchor has already been persisted — no
+field of any `ServerToAgent` message — including
 [`OpAMPConnectionSettings`](#opampconnectionsettings) — may be used to
-update or replace the Agent's payload trust anchor. This is a deliberate
-constraint to prevent a compromised Server from rotating the Agent onto
-an attacker-controlled trust anchor.
+update or replace the Agent's payload trust anchor. This constraint prevents a
+compromised Server from rotating the Agent onto an attacker-controlled trust anchor.
 
 When the payload trust anchor approaches expiry or must be replaced,
 rotation is handled by the same out-of-band mechanism used to provision
@@ -3678,7 +3681,82 @@ it initially (for example, updating the certificate file in the Agent's
 configuration and restarting the Agent). Operators SHOULD plan for this
 operational burden, such as using a long-lived root CA or automating
 certificate distribution through their existing configuration-management
-tooling.
+tooling. The same out-of-band rotation applies to TOFU-enrolled anchors:
+to rotate, delete the persisted anchor file and restart the Agent.
+
+### Trust On First Use (TOFU)
+
+Agents that do not have a pre-configured payload trust anchor may opt in to
+Trust On First Use (TOFU) enrollment. On the first connection the Server
+delivers the root CA certificate in `TrustChainResponse.tofu_trust_anchor`;
+the Agent persists it as its payload trust anchor and uses it for all
+subsequent connections. TOFU is **disabled by default** and requires explicit
+operator configuration.
+
+#### Security implications
+
+TOFU provides **no security on the first connection**: if the first connection
+is intercepted or the Server is compromised at enrollment time, the Agent will
+pin to an attacker-controlled anchor. Operators SHOULD prefer pre-configuring the
+trust anchor through existing configuration-management tooling (Ansible, Chef,
+Puppet, a secrets manager, or a compiled-in certificate). Use TOFU only when
+out-of-band provisioning is impractical.
+
+TOFU is also unsuitable for **stateless or short-lived Agents** (for example,
+Agents running in ephemeral containers) that cannot persist state across restarts.
+Such Agents would re-enroll on every startup, effectively providing no
+protection.
+
+#### TOFU capability advertisement
+
+An Agent opts in to TOFU enrollment by setting both
+`AgentCapabilities_RequiresPayloadTrustVerification` and
+`AgentCapabilities_AcceptsPayloadTrustAnchorTOFU` in its `AgentToServer.capabilities`.
+An Agent MUST NOT set `AcceptsPayloadTrustAnchorTOFU` if it already has a
+persisted or pre-configured trust anchor — it MUST advertise only
+`RequiresPayloadTrustVerification` in that case.
+
+#### TOFU enrollment flow
+
+1. The Agent, having no trust anchor, sets both capability bits.
+2. The Server recognises `AcceptsPayloadTrustAnchorTOFU` and includes the root CA
+   PEM in `TrustChainResponse.tofu_trust_anchor` of the first `SignedServerToAgent`.
+3. The Agent receives the envelope, validates the certificate chain against the
+   delivered root CA, verifies the signature, and — if all checks pass — persists
+   `tofu_trust_anchor` as its payload trust anchor.
+4. On all subsequent connections the Agent advertises only
+   `RequiresPayloadTrustVerification` (not `AcceptsPayloadTrustAnchorTOFU`) and
+   uses the persisted anchor as if it were a pre-configured trust anchor.
+
+The Server MUST include `tofu_trust_anchor` when the Agent has set
+`AcceptsPayloadTrustAnchorTOFU` and the Server holds the root CA. If the Server
+cannot provide the root CA it MUST set `error_message` and omit
+`tofu_trust_anchor`, causing the Agent to terminate the connection.
+
+#### TOFU anchor immutability
+
+The Agent MUST NOT update a previously persisted or operator-configured trust
+anchor. If `tofu_trust_anchor` is delivered on a connection where the Agent
+already has a trust anchor, the Agent MUST ignore it. This constraint applies
+equally to TOFU-enrolled anchors and statically-configured anchors.
+
+**Rationale:** allowing a server-side anchor update would recreate the same attack
+vector that Message Attestation is designed to prevent. If the Server is
+compromised after TOFU enrollment, it must not be able to re-enroll the Agent
+onto an attacker-controlled anchor.
+
+#### TOFU anchor rotation
+
+To replace a TOFU-enrolled trust anchor (for example, when the enrolled CA is
+approaching expiry or has been compromised), the operator deletes the persisted
+anchor file and restarts the Agent. On restart the Agent has no anchor and will
+re-enroll using the new CA configured on the Server. This is deliberately
+out-of-band — the same mechanism used to rotate a statically-configured anchor.
+
+Operators SHOULD monitor the expiry of the enrolled CA and schedule rotation
+before the certificate expires. An expired enrolled CA will cause attestation
+failures on the next connection, rendering the Agent unable to receive any
+`ServerToAgent` messages until the anchor is rotated.
 
 ### Opt-in and Backwards Compatibility
 
@@ -3774,6 +3852,11 @@ first such envelope carries the signing certificate chain in
      including expired certificate, unknown issuer, missing
      `id-kp-codeSigning` EKU, failed name/policy constraints, or
      revocation — the Agent MUST terminate the connection.
+   * The Agent MUST verify that the leaf certificate's Subject
+     Alternative Name (SAN) extension contains a `dNSName` or
+     `iPAddress` entry matching the OpAMP server the Agent is connected
+     to (using the same hostname matching rules as TLS). If the SAN
+     check fails the Agent MUST terminate the connection.
    * On successful validation, the Agent stores the validated leaf
      certificate (or its public key) for the duration of the session.
      For WebSocket transport the session ends when the connection closes.
@@ -3945,6 +4028,14 @@ The signing leaf certificate MUST:
   signing certificate.
 * Be within its validity window
   (`notBefore <= currentTime < notAfter`) at every verification.
+* Contain a Subject Alternative Name (SAN) extension with a `dNSName`
+  entry that matches the hostname of the OpAMP distribution server the
+  Agent is connected to, or an `iPAddress` entry that matches the
+  server's IP address when the Agent connects by IP. During the
+  connection-time handshake the Agent MUST verify this match in
+  addition to standard X.509 path validation. This binds the signing
+  certificate to a specific deployment and prevents a key valid for one
+  server from being accepted by Agents of a different server.
 
 The certificate chain (intermediates plus leaf) MUST chain to the
 pre-configured payload trust anchor. The trust anchor itself is

--- a/specification.md
+++ b/specification.md
@@ -3662,8 +3662,7 @@ combination of private-key isolation and EKU constraints — not a
 requirement for a separate root CA.
 
 The Server is independently configured with a signing key and its
-corresponding certificate chain that validates back to the payload trust
-anchor.
+corresponding certificate chain rooted in the payload trust anchor.
 
 The payload trust anchor is NEVER sent from the Server to the Agent. In particular,
 no field of any `ServerToAgent` message — including

--- a/specification.md
+++ b/specification.md
@@ -3750,7 +3750,7 @@ first such envelope carries the signing certificate chain in
      envelope. There is no exception for the first message.
    * Sets `payload` to the marshalled bytes of a `ServerToAgent`
      message containing whatever the Server would have sent had
-     signing not been negotiated (for example, an empty `ServerToAgent`
+     signing not been negotiated (for example, a `ServerToAgent`
      acknowledging the Agent's status report, or a `ServerToAgent`
      carrying initial `remote_config`).
 

--- a/specification.md
+++ b/specification.md
@@ -3998,9 +3998,7 @@ serialisation between implementations.
 
 ### Algorithm
 
-The signing algorithm is determined by the leaf certificate's
-`signatureAlgorithm` field. The OpAMP protocol does not negotiate
-algorithms.
+The signing algorithm is determined by the leaf certificate's public key (subjectPublicKeyInfo), paired with the hash function specified for that key type in the list below. The OpAMP protocol does not negotiate algorithms.
 
 Implementations SHOULD support, at minimum, the following algorithms:
 

--- a/specification.md
+++ b/specification.md
@@ -54,6 +54,8 @@ Status: [Beta]
       - [ServerToAgent.command](#servertoagentcommand)
       - [ServerToAgent.custom_capabilities](#servertoagentcustom_capabilities)
       - [ServerToAgent.custom_message](#servertoagentcustom_message)
+      - [ServerToAgent.trust_chain_response](#servertoagenttrust_chain_response)
+      - [ServerToAgent.signature](#servertoagentsignature)
     + [ServerErrorResponse Message](#servererrorresponse-message)
       - [ServerErrorResponse.type](#servererrorresponsetype)
       - [ServerErrorResponse.error_message](#servererrorresponseerror_message)
@@ -225,6 +227,20 @@ Status: [Beta]
   * [Configuration Restrictions](#configuration-restrictions)
   * [Opt-in Remote Configuration](#opt-in-remote-configuration)
   * [Code Signing](#code-signing)
+- [Message Attestation](#message-attestation)
+  * [Motivation and Threat Model](#motivation-and-threat-model)
+  * [Trust Model](#trust-model)
+  * [Opt-in and Backwards Compatibility](#opt-in-and-backwards-compatibility)
+  * [Capability Negotiation](#capability-negotiation)
+  * [Connection-Time Handshake](#connection-time-handshake)
+    + [TrustChainResponse Message](#trustchainresponse-message)
+      - [TrustChainResponse.certificate_chain](#trustchainresponsecertificate_chain)
+      - [TrustChainResponse.error_message](#trustchainresponseerror_message)
+  * [In-Session Signature Verification](#in-session-signature-verification)
+  * [Algorithm](#algorithm)
+  * [Certificate Requirements](#certificate-requirements)
+  * [Failure Modes](#failure-modes)
+  * [Out of Scope](#out-of-scope)
 - [Interoperability](#interoperability)
   * [Interoperability of Partial Implementations](#interoperability-of-partial-implementations)
   * [Interoperability of Future Capabilities](#interoperability-of-future-capabilities)
@@ -656,6 +672,12 @@ enum AgentCapabilities {
     // The agent will report ConnectionSettingsOffers status via AgentToServer.connection_settings_status field.
     // Status: [Development]
     ReportsConnectionSettingsStatus = 0x00008000;
+    // The Agent requires the payload trust verification handshake on connection
+    // and signature verification on every subsequent ServerToAgent message.
+    // If the Server does not offer this capability, the Agent MUST terminate
+    // the connection. See the [Message Attestation](#message-attestation) section.
+    // Status: [Development]
+    RequiresPayloadTrustVerification = 0x00010000;
 
     // Add new capabilities here, continuing with the least significant unused bit.
 }
@@ -917,6 +939,11 @@ enum ServerCapabilities {
     // The Server can accept ConnectionSettingsRequest and respond with an offer.
     // Status: [Development]
     AcceptsConnectionSettingsRequest = 0x00000040;
+    // The Server can respond to the payload trust verification handshake and
+    // sign every ServerToAgent message it sends after the handshake.
+    // See the [Message Attestation](#message-attestation) section.
+    // Status: [Development]
+    OffersPayloadTrustVerification = 0x00000080;
 
     // Add new capabilities here, continuing with the least significant unused bit.
 }
@@ -961,6 +988,32 @@ Status: [Development]
 A custom message sent from the Server to an Agent.
 
 See [CustomMessage](#custommessage) message for details.
+
+##### ServerToAgent.trust_chain_response
+
+Status: [Development]
+
+Sent by the Server in its first `ServerToAgent` message in response to an
+Agent that has set the
+[`RequiresPayloadTrustVerification`](#agenttoservercapabilities) capability. The
+Agent uses the contained certificate chain to verify the signature on
+every subsequent `ServerToAgent` message.
+
+See the [Message Attestation](#message-attestation) section for the full
+handshake and verification procedure, and the
+[`TrustChainResponse`](#trustchainresponse-message) message for the field
+layout.
+
+##### ServerToAgent.signature
+
+Status: [Development]
+
+The signature of this `ServerToAgent` message. Set by the Server only
+after a successful payload trust verification handshake, and verified by
+the Agent against the leaf certificate established by that handshake.
+
+The exact bytes that are signed and the verification procedure are
+defined in the [Message Attestation](#message-attestation) section.
 
 #### ServerErrorResponse Message
 
@@ -3541,8 +3594,11 @@ Agent by default. The capabilities should be opt-in by the user.
 ### Code Signing
 
 Any executable code that is part of a package should be signed
-to prevent a compromised Server from delivering malicious code to the Agent. We
-recommend the following:
+to prevent a compromised Server from delivering malicious code to the Agent.
+For end-to-end integrity of OpAMP messages themselves (including remote
+configuration offers, package offers, and Server-issued commands), see the
+[Message Attestation](#message-attestation) section.
+We recommend the following:
 
 * Any downloadable executable code (e.g. executable packages)
   need to be code-signed. The actual code-signing and verification mechanism is
@@ -3560,6 +3616,311 @@ recommend the following:
   code that it runs as external processes) at the minimum possible privilege to
   prevent the code from accessing sensitive files or perform high privilege
   operations. The Agent should not run downloaded code as root user.
+
+## Message Attestation
+
+**Status: [Development]**
+
+This section specifies an optional, end-to-end integrity mechanism for
+`ServerToAgent` messages based on X.509 certificate chains. When both the
+Server and the Agent opt in, every `ServerToAgent` message sent after the
+initial handshake carries a signature that the Agent verifies against a
+pre-configured trust anchor (a CA certificate) that is **distinct** from
+the TLS certificate authority used to establish the transport.
+
+The mechanism allows OpAMP deployments to separate the _distribution
+server_ from the _authoritative source of OpAMP messages_. A compromised
+distribution server cannot, in this model, push arbitrary configuration
+or commands to an Agent, because every message must be signed by a key
+whose trust chain validates against the Agent's pre-configured root.
+
+### Motivation and Threat Model
+
+TLS provides transport-level security between Server and Agent. It does
+not provide end-to-end integrity from the authoritative source of OpAMP
+messages: if TLS is terminated at a third-party load balancer, or if a
+managed OpAMP server is operated by a vendor, the distribution server
+can be a single point of control over the fleet. Even when TLS is not
+terminated by a third party, a software exploit of the distribution
+server (for example, a remote code execution vulnerability) could allow
+an attacker to take over the entire fleet.
+
+Without message-level signatures, the following attack vectors are not
+mitigated by the protocol itself:
+
+* A compromised distribution server may forge or modify
+  [`ServerToAgent.remote_config`](#servertoagentremote_config),
+  [`ServerToAgent.connection_settings`](#servertoagentconnection_settings),
+  [`ServerToAgent.packages_available`](#servertoagentpackages_available),
+  [`ServerToAgent.command`](#servertoagentcommand),
+  [`ServerToAgent.agent_identification`](#servertoagentagent_identification),
+  or any other field, even though such messages did not originate from
+  the intended authoritative source.
+
+* An internal attacker who can access the distribution server's stored
+  state, but not the signing keys, can still alter OpAMP messages in
+  flight.
+
+Message Attestation does **not** address:
+
+* Encryption of `ServerToAgent` or `AgentToServer` message contents
+  (the transport-level encryption provided by TLS remains the mechanism
+  for confidentiality).
+* Authentication of `AgentToServer` messages (the Server's ability to
+  verify the authenticity of Agent messages is out of scope for this
+  section; see
+  [opamp-spec issue #20](https://github.com/open-telemetry/opamp-spec/issues/20)).
+
+### Trust Model
+
+The Agent is pre-configured with a single root CA certificate, referred
+to in this section as the _payload trust anchor_. This certificate is
+operator-managed and is supplied to the Agent through
+implementation-specific configuration (for example, a file path in the
+Agent's configuration). The payload trust anchor MUST NOT be the same
+certificate as the TLS root the Agent uses to validate the transport —
+using the same root would collapse two separate trust domains into one
+and eliminate the security benefit.
+
+The Server is independently configured with a signing key and its
+corresponding certificate chain that validates back to the payload trust
+anchor.
+
+The payload trust anchor is NEVER pushed by the Server. In particular,
+no field of any `ServerToAgent` message — including
+[`OpAMPConnectionSettings`](#opampconnectionsettings) — may be used to
+update or replace the Agent's payload trust anchor. This is a deliberate
+constraint to prevent a compromised Server from rotating the Agent onto
+an attacker-controlled trust anchor.
+
+### Opt-in and Backwards Compatibility
+
+Message Attestation is a strict opt-in feature.
+
+**Implementations that do not implement Message Attestation are not
+required to change. Existing OpAMP deployments are unaffected by this
+specification until both sides opt in.**
+
+* Agents opt in by configuring a payload trust anchor at startup.
+  Opting in causes the Agent to set the
+  [`RequiresPayloadTrustVerification`](#agenttoservercapabilities) capability
+  bit in its first `AgentToServer.capabilities`.
+* Servers opt in by configuring a signing key and certificate chain.
+  Opting in causes the Server to set the
+  [`OffersPayloadTrustVerification`](#servertoagentcapabilities) capability
+  bit in its `ServerToAgent.capabilities`.
+
+The new capability bits are additions to a 64-bit bitmask.
+Implementations that do not recognise the new bits will simply not match
+them and will behave exactly as today. The new `ServerToAgent` fields
+(`trust_chain_response` and `signature`) are proto3 scalar/message
+additions and are ignored by implementations that predate them.
+
+A Server may advertise `OffersPayloadTrustVerification` and only sign
+`ServerToAgent` messages on connections from Agents that have set
+`RequiresPayloadTrustVerification` — there is no per-message cost for
+advertising the capability to non-opted-in Agents.
+
+### Capability Negotiation
+
+| Agent `Requires` | Server `Offers` | Behaviour |
+| --- | --- | --- |
+| No | No | Plain OpAMP. Today's behaviour. |
+| No | Yes | Plain OpAMP. The Server is capable of signing but the Agent has not opted in, so no `trust_chain_response` is sent and no signatures are emitted. |
+| Yes | No | The Server's first `ServerToAgent` lacks `trust_chain_response`. The Agent MUST terminate the connection. |
+| Yes | Yes | Handshake on the first `ServerToAgent`; per-message signatures thereafter. Specified in the remainder of this section. |
+
+### Connection-Time Handshake
+
+When the Agent has set `RequiresPayloadTrustVerification` and the Server
+has set `OffersPayloadTrustVerification`, the first `ServerToAgent`
+message exchanged on the connection MUST carry a
+[`trust_chain_response`](#servertoagenttrust_chain_response).
+
+1. The Agent's first `AgentToServer` message sets the
+   `RequiresPayloadTrustVerification` bit in `capabilities`.
+
+2. The Server's first `ServerToAgent` message:
+   * MUST set `trust_chain_response.certificate_chain` to the ordered
+     list of certificates from the first intermediate down to the
+     signing leaf certificate. The root certificate (the Agent's
+     pre-configured payload trust anchor) MUST NOT be included in this
+     chain.
+   * MAY set `trust_chain_response.error_message` if the Server cannot
+     satisfy the trust chain request (for example, because its signing
+     key is unavailable). When `error_message` is non-empty,
+     `certificate_chain` SHOULD be empty.
+   * MAY omit the [`signature`](#servertoagentsignature) field on this
+     first message. Trust on the first message is established by chain
+     validation against the pre-configured trust anchor, not by a
+     self-signature. Every subsequent `ServerToAgent` MUST be signed.
+
+3. The Agent receives the Server's first `ServerToAgent` and:
+   * If `trust_chain_response` is unset, the Agent MUST terminate the
+     connection.
+   * If `trust_chain_response.error_message` is non-empty, the Agent
+     MUST terminate the connection.
+   * Otherwise the Agent performs standard X.509 path validation of
+     `certificate_chain` using the pre-configured payload trust anchor
+     as the trust root. If validation fails — for any reason, including
+     expired leaf, expired intermediate, unknown issuer, missing
+     `id-kp-codeSigning` Extended Key Usage on the leaf, or revocation
+     — the Agent MUST terminate the connection.
+   * On successful validation, the Agent stores the validated leaf
+     certificate (or its public key) for the duration of the connection
+     and uses it to verify every subsequent `ServerToAgent` message.
+
+#### TrustChainResponse Message
+
+```protobuf
+message TrustChainResponse {
+    message Certificate {
+        // The certificate in DER format.
+        bytes der_data = 1;
+    }
+
+    // The certificate chain, ordered from the first intermediate
+    // certificate down to the signing leaf certificate. The root
+    // certificate is excluded; the Agent already possesses the root as
+    // its pre-configured payload trust anchor.
+    repeated Certificate certificate_chain = 1;
+
+    // Human-readable error message indicating why the Server could not
+    // satisfy the trust chain request. If error_message is non-empty,
+    // the Agent MUST terminate the connection.
+    string error_message = 2;
+}
+```
+
+##### TrustChainResponse.certificate_chain
+
+Ordered list of certificates from the first intermediate down to the
+signing leaf certificate. The root certificate is excluded. Each entry
+is a `Certificate` message whose `der_data` field holds the DER-encoded
+certificate.
+
+##### TrustChainResponse.error_message
+
+Human-readable error description set by the Server when it cannot
+satisfy the trust chain request. When non-empty, `certificate_chain`
+SHOULD be empty and the Agent MUST terminate the connection.
+
+### In-Session Signature Verification
+
+For every `ServerToAgent` message after the first, the Server MUST set
+the `signature` field to a signature over the message bytes, computed as
+follows:
+
+1. Construct the `ServerToAgent` message with all required fields set
+   except `signature`, which is left empty (zero-length).
+2. Serialise the message using deterministic Protocol Buffers encoding
+   (for example, Go's `proto.MarshalOptions{Deterministic: true}` or
+   the equivalent in other implementations).
+3. Sign the resulting byte string with the Server's signing private
+   key, using the signature algorithm declared by the leaf
+   certificate's `signatureAlgorithm` field.
+4. Set `signature` to the resulting signature bytes.
+
+The Agent verifies a received `ServerToAgent` message as follows:
+
+1. Extract the `signature` field. If `signature` is empty or absent on
+   any message after the handshake, the Agent MUST terminate the
+   connection.
+2. Construct a copy of the received message with `signature` cleared
+   (set to empty bytes).
+3. Serialise the copy using deterministic Protocol Buffers encoding.
+4. Verify the extracted `signature` against the resulting byte string
+   using the public key of the leaf certificate established during the
+   handshake, and the signature algorithm declared by the leaf
+   certificate's `signatureAlgorithm`.
+5. If verification fails, the Agent MUST terminate the connection.
+
+Implementations MUST use deterministic Protocol Buffers encoding for
+both signing and verification. Cross-language implementations must
+produce byte-identical canonical serialisations for the signed payload
+to interoperate.
+
+### Algorithm
+
+The signing algorithm is determined by the leaf certificate's
+`signatureAlgorithm` field. The OpAMP protocol does not negotiate
+algorithms.
+
+Implementations SHOULD support, at minimum, the following algorithms:
+
+* ECDSA P-256 with SHA-256
+* ECDSA P-384 with SHA-384
+* RSA-2048 or larger with PKCS#1 v1.5 and SHA-256
+* Ed25519
+
+These algorithms are covered by the default X.509 stacks of Go
+(`crypto/x509`), Java (`java.security`), and Python (`cryptography`).
+
+Future algorithm additions require no change to the OpAMP protocol; new
+algorithms are signalled by the certificate and supported by stacks as
+they evolve.
+
+### Certificate Requirements
+
+The signing leaf certificate MUST:
+
+* Include the Extended Key Usage extension with `id-kp-codeSigning`
+  (`1.3.6.1.5.5.7.3.3`) in its list of allowed usages. This prevents a
+  certificate intended for TLS server authentication from being used
+  to sign OpAMP messages.
+* Be within its validity window
+  (`notBefore <= currentTime < notAfter`) at every verification.
+
+The certificate chain (intermediates plus leaf) MUST chain to the
+pre-configured payload trust anchor. The trust anchor itself is
+supplied out-of-band and MUST NOT be included in the
+`certificate_chain` field of `trust_chain_response`.
+
+Revocation checking is RECOMMENDED. Implementations SHOULD use the
+revocation-checking facilities of their X.509 library (CRL distribution
+points, OCSP) during chain validation. Operators MAY rely on
+short-lived certificates as an alternative to active revocation.
+
+### Failure Modes
+
+Every failure listed below MUST cause the Agent to terminate the OpAMP
+connection. Recovery is by reconnection; the Server presents a
+(potentially rotated) chain on the new handshake.
+
+| Failure | When detected |
+| --- | --- |
+| Agent set `RequiresPayloadTrustVerification` but the Server did not set `OffersPayloadTrustVerification`. | First `ServerToAgent` (capability bits visible at that time). |
+| Server's first `ServerToAgent` does not include `trust_chain_response`. | First `ServerToAgent`. |
+| `trust_chain_response.error_message` is non-empty. | First `ServerToAgent`. |
+| Certificate chain fails X.509 path validation (expired certificate, unknown issuer, missing `id-kp-codeSigning` EKU, revoked certificate, etc.). | First `ServerToAgent`. |
+| In-session `ServerToAgent` message lacks `signature`. | Any subsequent `ServerToAgent`. |
+| In-session `signature` does not verify against the stored leaf certificate. | Any subsequent `ServerToAgent`. |
+| Stored leaf certificate's validity window has expired since the handshake. | The next verification after expiry. |
+
+### Out of Scope
+
+The following are explicitly out of scope for this version of Message
+Attestation. They MAY be revisited in future versions of the
+specification.
+
+* **Encryption of message contents.** TLS continues to provide
+  transport-level confidentiality. Message Attestation adds integrity,
+  not confidentiality.
+* **Authentication of `AgentToServer` messages.** Verifying the
+  authenticity of Agent-originated messages is tracked separately in
+  [opamp-spec issue #20](https://github.com/open-telemetry/opamp-spec/issues/20).
+* **Trust anchor distribution by the Server.** The payload trust anchor
+  is operator-managed and MUST NOT be modified by any field of any
+  `ServerToAgent` message.
+* **Algorithm negotiation.** The certificate's `signatureAlgorithm` is
+  authoritative. Future algorithm support is added by certificate
+  issuers and X.509 stacks, not by changes to OpAMP.
+* **Per-message-type opt-out (signing allowlist).** Mechanisms by which
+  an Agent might accept some `ServerToAgent` message types unsigned —
+  for example, to allow a third-party fleet manager to push low-risk
+  read-only telemetry settings while still requiring authoritative
+  signatures for configuration or command messages — are deferred to a
+  follow-up specification.
 
 ## Interoperability
 

--- a/specification.md
+++ b/specification.md
@@ -3737,10 +3737,10 @@ first such envelope carries the signing certificate chain in
 2. The Server, on receiving the Agent's first message and recognising
    the capability:
    * Sends its first `SignedServerToAgent` containing
-     `trust_chain_response.certificate_chain` ordered from the first
-     intermediate down to the signing leaf certificate. The root
-     certificate (the Agent's pre-configured payload trust anchor)
-     MUST NOT be included in this chain.
+     `trust_chain_response.certificate_chain` as a PEM blob ordered
+     from the first intermediate down to the signing leaf certificate.
+     The root certificate (the Agent's pre-configured payload trust
+     anchor) MUST NOT be included in this chain.
    * MAY set `trust_chain_response.error_message` if the Server cannot
      satisfy the trust chain request (for example, because its signing
      key is unavailable). When `error_message` is non-empty,
@@ -3764,10 +3764,11 @@ first such envelope carries the signing certificate chain in
      `SignedServerToAgent`.)
    * If `trust_chain_response.error_message` is non-empty, the Agent
      MUST terminate the connection.
-   * Otherwise the Agent MUST perform X.509 certification path
+   * Otherwise the Agent MUST decode the `certificate_chain` PEM blob
+     into individual certificates and perform X.509 certification path
      validation as defined in [RFC 5280 §6](https://datatracker.ietf.org/doc/html/rfc5280#section-6),
      using the pre-configured payload trust anchor as the sole trust
-     anchor, `certificate_chain` as the intermediate and leaf
+     anchor, the decoded certificates as the intermediate and leaf
      certificates, and `id-kp-codeSigning` (`1.3.6.1.5.5.7.3.3`) in the
      acceptable EKU set. If path validation fails for any reason —
      including expired certificate, unknown issuer, missing
@@ -3829,16 +3830,13 @@ See [TrustChainResponse Message](#trustchainresponse-message).
 
 ```protobuf
 message TrustChainResponse {
-    message Certificate {
-        // The certificate in DER format.
-        bytes der_data = 1;
-    }
-
-    // The certificate chain, ordered from the first intermediate
+    // PEM-encoded certificate chain, ordered from the first intermediate
     // certificate down to the signing leaf certificate. The root
     // certificate is excluded; the Agent already possesses the root as
-    // its pre-configured payload trust anchor.
-    repeated Certificate certificate_chain = 1;
+    // its pre-configured payload trust anchor. Multiple certificates are
+    // concatenated in a single PEM blob, consistent with the encoding
+    // used by TLSCertificate.
+    bytes certificate_chain = 1;
 
     // Human-readable error message indicating why the Server could not
     // satisfy the trust chain request. If error_message is non-empty,
@@ -3849,10 +3847,10 @@ message TrustChainResponse {
 
 ##### TrustChainResponse.certificate_chain
 
-Ordered list of certificates from the first intermediate down to the
-signing leaf certificate. The root certificate is excluded. Each entry
-is a `Certificate` message whose `der_data` field holds the DER-encoded
-certificate.
+PEM-encoded certificate chain, ordered from the first intermediate down
+to the signing leaf certificate. The root certificate is excluded.
+Multiple certificates are concatenated as a single PEM blob, consistent
+with the encoding used by `TLSCertificate.cert`.
 
 ##### TrustChainResponse.error_message
 

--- a/specification.md
+++ b/specification.md
@@ -3672,6 +3672,14 @@ update or replace the Agent's payload trust anchor. This is a deliberate
 constraint to prevent a compromised Server from rotating the Agent onto
 an attacker-controlled trust anchor.
 
+When the payload trust anchor approaches expiry or must be replaced,
+rotation is handled by the same out-of-band mechanism used to provision
+it initially (for example, updating the certificate file in the Agent's
+configuration and restarting the Agent). Operators SHOULD plan for this
+operational burden, such as using a long-lived root CA or automating
+certificate distribution through their existing configuration-management
+tooling.
+
 ### Opt-in and Backwards Compatibility
 
 Message Attestation is a strict opt-in feature.
@@ -3941,8 +3949,12 @@ short-lived certificates as an alternative to active revocation.
 ### Failure Modes
 
 Every failure listed below MUST cause the Agent to terminate the OpAMP
-connection. Recovery is by reconnection; the Server presents a
-(potentially rotated) chain on the new handshake.
+connection. The Agent SHOULD reconnect using exponential backoff consistent
+with normal OpAMP reconnection behaviour; on reconnection the Server presents
+a (potentially rotated) chain on the new handshake. Because these failures
+are detected locally by the Agent, no dedicated error-response field is
+required — the Agent terminates the connection without waiting for a
+`ServerToAgent.error_response`.
 
 | Failure | When detected |
 | --- | --- |

--- a/specification.md
+++ b/specification.md
@@ -3601,8 +3601,7 @@ This section specifies an optional, end-to-end integrity mechanism for
 `ServerToAgent` messages based on X.509 certificate chains. When both the
 Server and the Agent opt in, every `ServerToAgent` message sent after the
 initial handshake carries a signature that the Agent verifies against a
-pre-configured trust anchor (a CA certificate) that is **distinct** from
-the TLS certificate authority used to establish the transport.
+pre-configured trust anchor (a CA certificate).
 
 The mechanism allows OpAMP deployments to separate the _distribution
 server_ from the _authoritative source of OpAMP messages_. A compromised
@@ -3653,10 +3652,14 @@ The Agent is pre-configured with a single root CA certificate, referred
 to in this section as the _payload trust anchor_. This certificate is
 operator-managed and is supplied to the Agent through
 implementation-specific configuration (for example, a file path in the
-Agent's configuration). The payload trust anchor MUST NOT be the same
-certificate as the TLS root the Agent uses to validate the transport —
-using the same root would collapse two separate trust domains into one
-and eliminate the security benefit.
+Agent's configuration). The payload trust anchor MUST NOT carry the `id-kp-serverAuth`
+Extended Key Usage, ensuring it cannot double as a TLS CA certificate.
+Operators MAY root both the TLS chain and the signing chain from the
+same root CA, provided the signing intermediate and leaf certificates
+carry only `id-kp-codeSigning` and the signing private key is stored
+separately from the distribution server. The security boundary is the
+combination of private-key isolation and EKU constraints — not a
+requirement for a separate root CA.
 
 The Server is independently configured with a signing key and its
 corresponding certificate chain that validates back to the payload trust

--- a/specification.md
+++ b/specification.md
@@ -239,6 +239,7 @@ Status: [Beta]
       - [TrustChainResponse.certificate_chain](#trustchainresponsecertificate_chain)
       - [TrustChainResponse.error_message](#trustchainresponseerror_message)
   * [In-Session Signature Verification](#in-session-signature-verification)
+  * [Signing Certificate Rotation](#signing-certificate-rotation)
   * [Algorithm](#algorithm)
   * [Certificate Requirements](#certificate-requirements)
   * [Failure Modes](#failure-modes)
@@ -3881,7 +3882,8 @@ message SignedServerToAgent {
     // Detached signature over the bytes of the payload field.
     bytes signature = 15;
 
-    // Sent only in the first SignedServerToAgent on a connection.
+    // Sent on the first SignedServerToAgent and whenever the signing
+    // certificate chain rotates.
     TrustChainResponse trust_chain_response = 16;
 }
 ```
@@ -3904,10 +3906,16 @@ immediately using the signing key whose certificate chain is carried in
 
 ##### SignedServerToAgent.trust_chain_response
 
-Sent only in the first `SignedServerToAgent` on a connection. Carries
+Sent in the first `SignedServerToAgent` on a connection, and again
+whenever the signing certificate chain changes (see
+[Signing Certificate Rotation](#signing-certificate-rotation)). Carries
 the signing certificate chain the Agent uses to validate the leaf
-certificate and verify signatures on all messages including this one.
-See [TrustChainResponse Message](#trustchainresponse-message).
+certificate and verify signatures. When `trust_chain_response` carries a
+chain that differs from the one the Agent currently has pinned, the Agent
+MUST validate the new chain against its pre-configured payload trust
+anchor and re-pin the resulting leaf; a chain identical to the pinned one
+requires no action, as it has already been validated. See
+[TrustChainResponse Message](#trustchainresponse-message).
 
 #### TrustChainResponse Message
 
@@ -3970,11 +3978,13 @@ The Server produces a `SignedServerToAgent` as follows:
    Buffers encoder. (No special "deterministic" option is required;
    the only bytes that matter are the ones placed on the wire.)
 3. Compute a signature over those bytes using the Server's signing
-   private key and the signature algorithm declared by the leaf
-   certificate's `signatureAlgorithm` field.
+   private key and the algorithm indicated by the leaf certificate's
+   `subjectPublicKeyInfo`.
 4. Construct the outer `SignedServerToAgent` with `payload` set to the
    marshalled bytes from step 2 and `signature` set to the signature
-   from step 3. On the first message, also set `trust_chain_response`.
+   from step 3. On the first message, and again whenever the signing
+   chain has changed since it was last sent, also set
+   `trust_chain_response`.
 5. Marshal and send the `SignedServerToAgent`.
 
 The Agent verifies a received `SignedServerToAgent` as follows:
@@ -3982,19 +3992,63 @@ The Agent verifies a received `SignedServerToAgent` as follows:
 1. Parse the wire bytes as a `SignedServerToAgent`. Retain the
    `payload` field's raw bytes — these are the bytes the signature
    covers.
-2. If `signature` is empty or absent, the Agent MUST terminate the
+2. If `trust_chain_response` carries a chain that differs from the one
+   currently pinned (including the first message, when none is pinned
+   yet), validate it against the pre-configured payload trust anchor and
+   pin the resulting leaf certificate — the initial handshake, or a
+   rotation on a later message (see
+   [Signing Certificate Rotation](#signing-certificate-rotation)). If
+   validation fails, the Agent MUST terminate the connection. A chain
+   identical to the pinned one requires no re-validation. If
+   `trust_chain_response` is absent and no leaf has been pinned yet, the
+   Agent MUST terminate the connection.
+3. If `signature` is empty or absent, the Agent MUST terminate the
    connection.
-3. Verify `signature` over the `payload` bytes using the public key of
-   the leaf certificate established during the handshake, and the
-   signature algorithm declared by the leaf certificate's
-   `signatureAlgorithm`.
-4. If verification fails, the Agent MUST terminate the connection.
-5. On success, unmarshal the `payload` bytes into a `ServerToAgent`
+4. Verify `signature` over the `payload` bytes using the public key and
+   algorithm from the currently pinned leaf certificate
+   (`subjectPublicKeyInfo`).
+5. If verification fails, the Agent MUST terminate the connection.
+6. On success, unmarshal the `payload` bytes into a `ServerToAgent`
    and process it normally.
 
 Because the signature is detached, the Agent never needs to re-marshal
 the inner `ServerToAgent`. This eliminates any dependency on canonical
 serialisation between implementations.
+
+### Signing Certificate Rotation
+
+The Server's signing key, and therefore its certificate chain, is
+expected to rotate over the lifetime of a long-lived connection.
+Operators commonly rotate signing keys frequently (for example, hourly).
+Only the chain between the leaf and the root changes; the payload trust
+anchor (root) MUST NOT change (see [Trust Model](#trust-model)).
+
+To support rotation without dropping the connection:
+
+* The Server MUST send an updated `trust_chain_response` whenever the
+  signing certificate chain changes, carried by the same
+  `SignedServerToAgent` whose `signature` was produced with the new
+  leaf. The Server SHOULD deliver the new chain before the current leaf
+  certificate expires, so the Agent is never left unable to verify
+  messages.
+* On receiving a `trust_chain_response` whose chain differs from the one
+  it has pinned, the Agent MUST validate the new chain against its
+  (unchanged) pre-configured payload trust anchor, re-pin the resulting
+  leaf, and use it to verify the current and subsequent messages. A chain
+  identical to the pinned one is a no-op.
+
+A Server that never rotates its signing chain simply does not send a
+changed `trust_chain_response` after the first message. Because the
+payload trust anchor is fixed, rotation of the signing chain never
+requires re-provisioning the Agent.
+
+Note that the transports differ in how often the chain is delivered. Over
+WebSocket the Server holds one connection and sends `trust_chain_response`
+only on the first message and on each rotation. The plain HTTP transport
+is request/response with no persistent connection, so a Server MAY include
+`trust_chain_response` in every response; the Agent MUST treat re-delivery
+of an unchanged chain as a no-op rather than an error, comparing it against
+the currently pinned chain and re-validating only on a change.
 
 ### Algorithm
 

--- a/specification.md
+++ b/specification.md
@@ -239,6 +239,7 @@ Status: [Beta]
       - [TrustChainResponse.certificate_chain](#trustchainresponsecertificate_chain)
       - [TrustChainResponse.error_message](#trustchainresponseerror_message)
   * [In-Session Signature Verification](#in-session-signature-verification)
+  * [Heartbeat Response Exemption](#heartbeat-response-exemption)
   * [Signing Certificate Rotation](#signing-certificate-rotation)
   * [Algorithm](#algorithm)
   * [Certificate Requirements](#certificate-requirements)
@@ -3800,7 +3801,7 @@ on connections from Agents that have set `RequiresPayloadTrustVerification`.
 | No | No | Plain OpAMP. The Server sends `ServerToAgent` messages on the wire. Today's behaviour. |
 | No | Yes | Plain OpAMP. The Server is capable of signing but the Agent has not opted in, so the Server sends `ServerToAgent` messages on the wire (not `SignedServerToAgent`). |
 | Yes | No | The Server does not send `SignedServerToAgent`. The Agent receives a plain `ServerToAgent` where it expected a `SignedServerToAgent` envelope. The Agent MUST treat this as a failure as described in [Failure Modes](#failure-modes). |
-| Yes | Yes | Every Server-to-Agent message on the connection is wrapped in `SignedServerToAgent`. Handshake on the first message (carries `trust_chain_response`); per-message detached signatures thereafter. Specified in the remainder of this section. |
+| Yes | Yes | Server-to-Agent messages on the connection are wrapped in `SignedServerToAgent`. Handshake on the first signed message (carries `trust_chain_response`); per-message detached signatures thereafter. As a narrow exemption, a Server MAY send heartbeat responses unsigned (see [Heartbeat Response Exemption](#heartbeat-response-exemption)). Specified in the remainder of this section. |
 
 ### Connection-Time Handshake
 
@@ -3871,6 +3872,16 @@ first such envelope carries the signing certificate chain in
      connection.
    * The Agent then unmarshals the `payload` bytes into a
      `ServerToAgent` and processes it normally.
+
+> **Note.** On a negotiated connection the Server MAY answer with an
+> unsigned heartbeat response before it has any substantive content to
+> send (see [Heartbeat Response Exemption](#heartbeat-response-exemption)).
+> Such a message is a plain `ServerToAgent`, not a `SignedServerToAgent`,
+> and carries no `trust_chain_response`; the Agent accepts it as a
+> heartbeat, and the handshake completes on the first **signed**
+> `SignedServerToAgent`, which MUST carry `trust_chain_response`. The
+> termination rules in this section apply to messages that are not valid
+> heartbeat responses.
 
 #### SignedServerToAgent Message
 
@@ -4015,6 +4026,82 @@ Because the signature is detached, the Agent never needs to re-marshal
 the inner `ServerToAgent`. This eliminates any dependency on canonical
 serialisation between implementations.
 
+### Heartbeat Response Exemption
+
+The base protocol already defines a distinguished, content-free
+Server-to-Agent message: when the Server receives an `AgentToServer` and
+has no data to send back, it still sends a `ServerToAgent` with **all
+fields except `instance_uid` unset**, serving "simply as an
+acknowledgement of receipt" (see [ServerToAgent Message](#servertoagent-message)).
+This is the keepalive response the Agent receives on every HTTP poll, and
+whenever a WebSocket exchange needs only an acknowledgement.
+
+This section refers to that exact shape — a `ServerToAgent` in which only
+`instance_uid` is set and every other field is unset/default — as a
+**heartbeat response**. It is not a new message type; it is the existing
+acknowledgement-of-receipt response, named here so the signing exemption
+can reference it precisely.
+
+Requiring a signature on *every* message means that on the HTTP polling
+transport — where the Server MUST answer every poll — this
+acknowledgement-of-receipt response is signed on every polling interval,
+for every Agent. At fleet scale, per-message signing of these
+content-free responses can dominate the Server's signing cost. Message
+Attestation therefore permits, and narrowly bounds, an exemption for
+exactly this shape.
+
+On a connection where Message Attestation is negotiated:
+
+* A Server MAY send a heartbeat response as a plain (unsigned)
+  `ServerToAgent` — that is, **not** wrapped in a `SignedServerToAgent`
+  envelope. A Server MUST NOT send any other `ServerToAgent` unsigned;
+  every message that sets any field other than `instance_uid` MUST be
+  wrapped and signed as described above.
+* An Agent MUST accept a plain (unsigned) `ServerToAgent` **only if** it
+  is a heartbeat response as defined above (only `instance_uid` set, all
+  other fields unset/default). The Agent MUST reject any other plain
+  `ServerToAgent` and treat it as a failure per
+  [Failure Modes](#failure-modes).
+
+This check is **structural and default-deny**, and MUST be enforced by
+the Agent independently of the Server: the Agent inspects each unsigned
+`ServerToAgent` it receives and admits it only when it matches the exempt
+shape exactly. The Server's cooperation in sending only `instance_uid` is
+never trusted. The consequence for futureproofing is deliberate: any
+field added to `ServerToAgent` in a future version of this specification
+is, by default, outside the exempt shape, so a message that sets it can
+no longer be sent unsigned. New fields therefore never silently widen the
+unsigned surface; admitting a new field into the exemption would require
+an explicit change to this definition.
+
+The exemption does not alter the connection-time handshake or trust-chain
+delivery. `trust_chain_response` is carried on the first **signed**
+`SignedServerToAgent` (and again on rotation) as described in
+[Connection-Time Handshake](#connection-time-handshake) and
+[Signing Certificate Rotation](#signing-certificate-rotation). An
+unsigned heartbeat carries no chain and does not advance handshake state;
+an Agent that has not yet completed the handshake still requires the first
+signed message to carry a valid `trust_chain_response`.
+
+> **Why this is safe.** The exempt shape carries no field the Agent acts
+> on beyond `instance_uid`. An attacker who strips the signature from a
+> substantive message (configuration, command, capabilities, connection
+> settings, or any trust-anchor-affecting field) produces a message that
+> is not the exempt shape, so the Agent rejects it fail-closed. An
+> attacker who forges an unsigned heartbeat conveys nothing the Agent
+> acts upon. The exemption therefore does not open a signature-stripping
+> downgrade: it admits only messages that are inert by construction.
+>
+> Message Attestation does not currently define a replay-protection
+> primitive (such as a nonce or sequence number); signed messages are
+> themselves replayable, and an inert unsigned heartbeat does not worsen
+> this. If a future version adds a freshness field to every
+> `ServerToAgent`, the exempt-shape definition above MUST be updated to
+> account for it — either by permitting exactly that field on heartbeats
+> or by excluding heartbeats from the requirement — otherwise the
+> structural check will (correctly, by default-deny) begin requiring
+> heartbeats to be signed again.
+
 ### Signing Certificate Rotation
 
 The Server's signing key, and therefore its certificate chain, is
@@ -4112,10 +4199,10 @@ dedicated error-response field is required.
 
 | Failure | When detected |
 | --- | --- |
-| Agent set `RequiresPayloadTrustVerification` but the Server did not send a `SignedServerToAgent` envelope (typically because the Server does not support the capability and sent a plain `ServerToAgent`). | First message received from the Server. |
-| First `SignedServerToAgent` does not include `trust_chain_response`. | First message. |
-| `trust_chain_response.error_message` is non-empty. | First message. |
-| Certificate chain fails X.509 path validation (expired certificate, unknown issuer, missing `id-kp-codeSigning` EKU, revoked certificate, etc.). | First message. |
+| Agent set `RequiresPayloadTrustVerification` but the Server sent a plain `ServerToAgent` that is **not** a heartbeat response (typically because the Server does not support the capability, or attempted to deliver actionable content unsigned). A plain `ServerToAgent` that is a heartbeat response — only `instance_uid` set — is permitted and is **not** a failure (see [Heartbeat Response Exemption](#heartbeat-response-exemption)). | Any message received from the Server. |
+| First signed `SignedServerToAgent` does not include `trust_chain_response`. | First signed message. |
+| `trust_chain_response.error_message` is non-empty. | First signed message. |
+| Certificate chain fails X.509 path validation (expired certificate, unknown issuer, missing `id-kp-codeSigning` EKU, revoked certificate, etc.). | First signed message. |
 | `SignedServerToAgent` lacks `signature`. | Every message. |
 | `signature` does not verify against the stored leaf certificate over the received `payload` bytes. | Every message. |
 | Stored leaf certificate's validity window has expired since the handshake. | The next verification after expiry. |
@@ -4138,12 +4225,16 @@ specification.
 * **Algorithm negotiation.** The certificate's `signatureAlgorithm` is
   authoritative. Future algorithm support is added by certificate
   issuers and X.509 stacks, not by changes to OpAMP.
-* **Per-message-type opt-out (signing allowlist).** Mechanisms by which
-  an Agent might accept some `ServerToAgent` message types unsigned —
-  for example, to allow a third-party fleet manager to push low-risk
-  read-only telemetry settings while still requiring authoritative
-  signatures for configuration or command messages — are deferred to a
-  follow-up specification.
+* **General per-message-type opt-out (signing allowlist).** Mechanisms by
+  which an Agent might accept arbitrary `ServerToAgent` message types
+  unsigned — for example, to allow a third-party fleet manager to push
+  low-risk read-only telemetry settings while still requiring
+  authoritative signatures for configuration or command messages — are
+  deferred to a follow-up specification. The sole exemption defined by
+  this version is the content-free
+  [Heartbeat Response Exemption](#heartbeat-response-exemption); a
+  general allowlist covering content-bearing messages remains out of
+  scope.
 
 ## Interoperability
 

--- a/specification.md
+++ b/specification.md
@@ -3782,7 +3782,7 @@ them and will behave exactly as today.
 
 The `SignedServerToAgent` envelope is sent **only** when the negotiation
 succeeds. For connections where Message Attestation is not negotiated,
-the wire format is byte-identical to upstream OpAMP — the Server keeps
+the wire format is unchanged — the Server keeps
 sending plain `ServerToAgent` messages, and the Agent keeps parsing
 them as such. Implementations that do not implement Message Attestation
 therefore see no wire-format change at all.

--- a/specification.md
+++ b/specification.md
@@ -3858,7 +3858,13 @@ first such envelope carries the signing certificate chain in
      Alternative Name (SAN) extension contains a `dNSName` or
      `iPAddress` entry matching the OpAMP server the Agent is connected
      to (using the same hostname matching rules as TLS). If the SAN
-     check fails the Agent MUST terminate the connection.
+     check fails the Agent MUST terminate the connection. The leaf MAY
+     carry more than one SAN entry; the Agent matches against the single
+     host it actually connected to. This lets one signing certificate
+     serve a deployment reachable through more than one hostname — for
+     example, an OpAMP proxy in front of the origin server — without
+     weakening the match: the Agent still requires the connected host to
+     be present in the SAN set.
    * On successful validation, the Agent stores the validated leaf
      certificate (or its public key) for the duration of the session.
      For WebSocket transport the session ends when the connection closes.
@@ -4175,6 +4181,21 @@ The signing leaf certificate MUST:
   addition to standard X.509 path validation. This binds the signing
   certificate to a specific deployment and prevents a key valid for one
   server from being accepted by Agents of a different server.
+
+  The SAN extension MAY contain multiple `dNSName`/`iPAddress` entries,
+  one for each host through which Agents legitimately reach this
+  deployment. This is the supported way to place a proxy in front of the
+  origin server (for example, an OpAMP gateway): the proxy's hostname
+  and the origin server's hostname are both listed as SAN entries, so a
+  single signing key produces signatures accepted by Agents connecting
+  to either host. Each Agent verifies only the host it connected to.
+
+  Operators MUST enumerate the permitted hosts as SAN entries rather
+  than relaxing the Agent's hostname check. Configuring an Agent to
+  connect to one host while "expecting" a different name in the
+  certificate breaks the deployment-binding property — it is effectively
+  the same as disabling hostname verification in TLS — and a connection
+  to a host not present in the SAN set MUST still fail.
 
 The certificate chain (intermediates plus leaf) MUST chain to the
 pre-configured payload trust anchor. The trust anchor itself is

--- a/supplementary-guidelines.md
+++ b/supplementary-guidelines.md
@@ -1,0 +1,86 @@
+# Message Attestation: Supplementary Guidelines
+
+This document provides non-normative guidance for implementors and operators
+deploying Message Attestation. It is a companion to the normative
+[specification](specification.md).
+
+## Motivation
+
+OpAMP servers necessarily occupy a high-exposure position on the network: they
+must be reachable by every member of the fleet. A compromise of the OpAMP server
+(or a TLS-terminating proxy in front of it) would, without Message Attestation,
+yield full control over all connected Agents.
+
+Message Attestation addresses this by separating the *distribution* of messages
+from the *authorization* of messages. The distribution server remains at the
+network edge; the signing authority lives deeper in the infrastructure, away
+from the attack surface.
+
+## Example Deployment Architecture
+
+The following describes one example deployment. Actual deployments may be
+simpler or more complex depending on organisational requirements.
+
+![Example deployment architecture](https://github.com/user-attachments/assets/20fb3567-ff84-47f3-9e42-367953881232)
+
+1. The Agent connects to the OpAMP server at the network edge.
+2. The OpAMP server constructs a `ServerToAgent` payload to send to the Agent.
+3. Before sending, the OpAMP server submits the payload to an internal policy
+   engine.
+4. The policy engine evaluates whether the message is permitted for this Agent,
+   applying whatever organizational constraints are relevant.
+5. If the message is approved, the policy engine submits a signature request to
+   a secure signer (typically a hardware security module).
+6. The signer returns a signature over the payload bytes.
+7. The OpAMP server wraps the payload and signature in a `SignedServerToAgent`
+   envelope and delivers it to the Agent.
+
+The key security property is structural isolation: the decision of *what is
+allowed to be sent* is made by a component that is not directly reachable from
+the network edge. An attacker who compromises the OpAMP server gains the ability
+to send messages, but not the ability to have those messages accepted by Agents
+with `RequiresPayloadTrustVerification` set — because the attacker cannot
+produce valid signatures.
+
+## Policy Engine Constraints
+
+The policy engine can enforce any criteria the organization considers relevant.
+Examples include:
+
+- Denying specific message types outright (e.g. no `ServerToAgentCommand`).
+- Enforcing per-customer opt-ins and opt-outs.
+- Enforcing security invariants (e.g. a specific pipeline must never be
+  disabled).
+- Restricting which teams may push configuration changes.
+- Requiring that only the latest approved version of a component may be
+  installed.
+
+These constraints could in principle be enforced client-side, but expressing
+them flexibly would require significant complexity in Agent code. With Message
+Attestation, the protocol defines a lightweight stamp ("this message was
+authorized") and the Agent knows how to verify it; all bespoke policy logic
+is maintained in the backend by the organization itself.
+
+## Operational Considerations
+
+### Trust Anchor Lifecycle
+
+The payload trust anchor is a root CA certificate provisioned out-of-band on
+each Agent. It is deliberately not rotatable via OpAMP messages, to prevent a
+compromised server from redirecting Agents to an attacker-controlled anchor.
+
+Operators should plan for trust anchor rotation using their existing
+configuration-management tooling (e.g. Ansible, Chef, Puppet, or a secrets
+manager). Using a long-lived root CA and shorter-lived signing intermediates
+reduces rotation frequency for the trust anchor itself.
+
+### Certificate Revocation
+
+If a signing intermediate is compromised, standard X.509 revocation (CRL
+distribution points or OCSP) handles it. The spec recommends enabling
+revocation checking in the Agent's X.509 library. Operators may alternatively
+use short-lived signing certificates as a substitute for active revocation.
+
+If the root payload trust anchor itself is compromised, it must be replaced via
+the same out-of-band mechanism used to provision it. This is an intentional
+design constraint: no OpAMP message may update the trust anchor.

--- a/supplementary-guidelines.md
+++ b/supplementary-guidelines.md
@@ -21,7 +21,23 @@ from the attack surface.
 The following describes one example deployment. Actual deployments may be
 simpler or more complex depending on organisational requirements.
 
-![Example deployment architecture](https://github.com/user-attachments/assets/20fb3567-ff84-47f3-9e42-367953881232)
+```
+  Agent             OpAMP Server       Policy Engine        Signer
+                   (network edge)        (internal)          (HSM)
+     │                   │                   │                 │
+     │ (1) AgentToServer │                   │                 │
+     ├──────────────────►│                   │                 │
+     │                   │  (3) payload      │                 │
+     │                   ├──────────────────►│                 │
+     │                   │                   │ (5) sign req    │
+     │                   │                   ├────────────────►│
+     │                   │                   │ (6) signature   │
+     │                   │                   │◄────────────────┤
+     │                   │◄── signature ─────┤                 │
+     │ (7) Signed        │                   │                 │
+     │ ServerToAgent     │                   │                 │
+     │◄──────────────────┤                   │                 │
+```
 
 1. The Agent connects to the OpAMP server at the network edge.
 2. The OpAMP server constructs a `ServerToAgent` payload to send to the Agent.
@@ -61,6 +77,39 @@ Attestation, the protocol defines a lightweight stamp ("this message was
 authorized") and the Agent knows how to verify it; all bespoke policy logic
 is maintained in the backend by the organization itself.
 
+## Certificate Hierarchy and Extended Key Usage
+
+X.509 certificates carry an *Extended Key Usage* (EKU) field that declares
+what a certificate is permitted to do. Two EKU values are relevant to Message
+Attestation:
+
+- **`id-kp-serverAuth`** — the certificate may authenticate a TLS server. TLS
+  clients check for this when establishing a secure connection.
+- **`id-kp-codeSigning`** — the certificate may sign arbitrary data. Message
+  Attestation uses this EKU to mark signing certificates.
+
+The spec requires the signing leaf certificate to carry `id-kp-codeSigning` and
+prohibits `id-kp-serverAuth` on it. This means a TLS certificate cannot be
+repurposed to sign OpAMP messages, and a signing certificate cannot be used as
+a TLS server certificate.
+
+### Do I need a separate root CA for signing?
+
+No. The same root CA may issue both TLS and signing certificates, provided:
+
+1. Each intermediate and leaf certificate carries only the appropriate EKU.
+2. The signing private key is stored separately from the distribution server —
+   for example, in an HSM or secrets manager the distribution server process
+   cannot reach.
+
+The security boundary is *key isolation*, not *CA isolation*. An attacker who
+compromises the distribution server but cannot access the signing private key
+cannot forge valid signed messages, regardless of whether TLS and signing
+certificates share a root.
+
+Operators who prefer strict CA separation may use separate roots, but it is not
+required.
+
 ## Operational Considerations
 
 ### Trust Anchor Lifecycle
@@ -73,6 +122,13 @@ Operators should plan for trust anchor rotation using their existing
 configuration-management tooling (e.g. Ansible, Chef, Puppet, or a secrets
 manager). Using a long-lived root CA and shorter-lived signing intermediates
 reduces rotation frequency for the trust anchor itself.
+
+An alternative approach is to compile the trust anchor directly into the Agent
+binary. In this model, trust anchor rotation is handled by distributing a new
+Agent version — the same mechanism used for any other Agent update. This can be
+simpler to operate in environments where Agent binary updates are already
+automated, and it avoids the need for a separate certificate-management
+pipeline.
 
 ### Certificate Revocation
 


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opamp-spec/issues/265, see [proposal document](https://docs.google.com/document/d/10IwvaEMs-CqE6OmTcGJHMf7TwJJPqvAabCjMQ5OTcP4/edit?tab=t.8gtjif5uhm5o) for context.

## Summary
This PR introduces an optional, end-to-end integrity mechanism for `ServerToAgent` messages based on X.509 certificate chains. When both the Server and the Agent opt in, every `ServerToAgent` message sent after the initial handshake carries a signature that the Agent verifies against a pre-configured trust anchor (a CA certificate) that is **distinct** from the TLS certificate authority used to establish the transport.

The mechanism allows OpAMP deployments to separate the _distribution server_ from the _authoritative source of OpAMP messages_. A compromised distribution server cannot, in this model, push arbitrary configuration or commands to an Agent, because every message must be signed by a key whose trust chain validates against the Agent's pre-configured root.

Strict opt-in: implementations that do not implement Message Attestation require no changes. Existing OpAMP deployments are unaffected until both sides opt in.

## Changes
Wire-level changes (all Status: [Development]):
* AgentCapabilities.RequiresPayloadTrustVerification = 0x00010000
* ServerCapabilities.OffersPayloadTrustVerification = 0x00000080
* ServerToAgent.trust_chain_response = 12 (new TrustChainResponse message)
* ServerToAgent.signature = 13

The new "Message Attestation" section in `specification.md` covers the threat model, trust model, opt-in semantics, capability negotiation, connection-time handshake, in-session per-message verification, the heartbeat response exemption (an empty heartbeat response — only `instance_uid` set — MAY be sent unsigned; anything else unsigned is rejected), algorithm selection (any X.509-supported), certificate requirements (including multi-SAN signing certificates so a single key can serve an OpAMP gateway/proxy in front of the origin server without relaxing the Agent's hostname check), failure modes (all result in agent disconnect), and out-of-scope items.

### Client-facing changes
To enable verification of messages, the OpAMP client is configured with a root certificate to trust at startup via a config value:
```
extensions:
  opamp:
    server:
      payload_ca: /etc/opamp/securecorp-ca.pem
      ws:
        endpoint: wss://127.0.0.1:4320/v1/opamp
```
When provided, the client will indicate to the server that it requires authenticated payloads, and use the provided root certificate to verify messages the server sends.


## Motivation
The OpAMP Server is currently treated as both a point of distribution and the authoritative source of OpAMP messages. If an OpAMP Server is compromised, clients can be subject to significant security vulnerabilities such as forced restarts, breaches of sensitive information, and unintended binary updates. By requiring messages to be signed by an authoritative source, an attacker gaining access to the OpAMP Server would not be able to sign messages that do not meet strict validation/type requirements. OpAMP Agents will also have the capability to reject messages with invalid certificates, and can immediately terminate the connection, preventing further attacks.
