### PR TITLE
Add ComponentHealth.attributes

### DIFF
--- a/proto/opamp.proto
+++ b/proto/opamp.proto
@@ -812,6 +812,7 @@ message ComponentHealth {
     map<string, ComponentHealth> component_health_map = 6;
 
     // Additional context or metadata for the observed component's status.
+    // Attributes are component specific and outside the concerns of the OpAMP protocol.
     repeated KeyValue attributes = 7;
 }
 

--- a/proto/opamp.proto
+++ b/proto/opamp.proto
@@ -810,6 +810,9 @@ message ComponentHealth {
     // A map to store more granular, sub-component health. It can nest as deeply as needed to
     // describe the underlying system.
     map<string, ComponentHealth> component_health_map = 6;
+
+    // Additional context or metadata for the observed component's status.
+    repeated KeyValue attributes = 7;
 }
 
 message EffectiveConfig {

--- a/proto/opamp.proto
+++ b/proto/opamp.proto
@@ -813,6 +813,7 @@ message ComponentHealth {
 
     // Additional context or metadata for the observed component's status.
     // Attributes are component specific and outside the concerns of the OpAMP protocol.
+    // Status: [Development]
     repeated KeyValue attributes = 7;
 }
 

--- a/specification.md
+++ b/specification.md
@@ -72,6 +72,7 @@ Status: [Beta]
       - [ComponentHealth.status](#componenthealthstatus)
       - [ComponentHealth.status_time_unix_nano](#componenthealthstatus_time_unix_nano)
       - [ComponentHealth.component_health_map](#componenthealthcomponent_health_map)
+      - [ComponentHealth.attributes](#componenthealthattributes)
     + [EffectiveConfig Message](#effectiveconfig-message)
       - [EffectiveConfig.config_map](#effectiveconfigconfig_map)
     + [RemoteConfigStatus Message](#remoteconfigstatus-message)
@@ -1242,6 +1243,7 @@ message ComponentHealth {
     string status = 4;
     fixed64 status_time_unix_nano = 5;
     map<string, ComponentHealth> component_health_map = 6;
+    repeated KeyValue attributes = 7;
 }
 ```
 
@@ -1274,6 +1276,10 @@ nanoseconds since 00:00:00 UTC on 1 January 1970.
 
 A map to store more granular, sub-component health. It can nest as deeply as needed to
 describe the underlying system.
+
+##### ComponentHealth.attributes
+
+Additional context or metadata for the observed component's status.
 
 #### EffectiveConfig Message
 

--- a/specification.md
+++ b/specification.md
@@ -1280,6 +1280,7 @@ describe the underlying system.
 ##### ComponentHealth.attributes
 
 Additional context or metadata for the observed component's status.
+Attributes are component specific and outside the concerns of the OpAMP protocol.
 
 #### EffectiveConfig Message
 


### PR DESCRIPTION
Add `attributes` in order to be consistent with what the healthcheck extension produces. See [extension source](https://github.com/open-telemetry/opentelemetry-collector/blob/8ca992c832690e561f7fe70563ac48ec8c37bb0e/component/componentstatus/status.go#L87-L96).

- Closes #326 