### PR TITLE
Add typos check workflow

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -49,6 +49,15 @@ jobs:
     - name: validate markdown-toc
       run: git diff --exit-code ':*.md' || (echo 'Generated markdown Table of Contents is out of date, please run "make markdown-toc" and commit the changes in this PR.' && exit 1)
 
+  check-typos:
+    runs-on: ubuntu-latest
+    steps:
+      - name: check out code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: check for typos
+        uses: crate-ci/typos@bbaefadf97b0ec5fdc942684b647f1a6ab250274 # v1.46.0
+
   gen-proto:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ all: markdown-toc markdown-link-check markdownlint gen-proto
 # This target runs markdown-toc on all files that contain
 # a comment <!-- tocstop -->.
 #
-# The recommended way to prepate a .md file for markdown-toc is
+# The recommended way to prepare a .md file for markdown-toc is
 # to add these comments:
 #
 #   <!-- toc -->

--- a/proto/opamp.proto
+++ b/proto/opamp.proto
@@ -833,7 +833,7 @@ message RemoteConfigStatus {
 
 // Status: [Development]
 message ConnectionSettingsStatus {
-    // The hash of the connection settings that was last recieved by this Agent
+    // The hash of the connection settings that was last received by this Agent
     // in the connection_settings.hash field. The Server SHOULD compare this
     // hash with the OfferedConnectionSettings hash it has for the Agent and if
     // the hashes are different the Server MUST include the connection_settings

--- a/specification.md
+++ b/specification.md
@@ -140,7 +140,7 @@ Status: [Beta]
       - [TLSConnectionSettings.insecure_skip_verify](#tlsconnectionsettingsinsecure_skip_verify)
       - [TLSConnectionSettings.min_version](#tlsconnectionsettingsmin_version)
       - [TLSConnectionSettings.max_version](#tlsconnectionsettingsmax_version)
-      - [TLSConnectionSettings.ciper_suites](#tlsconnectionsettingsciper_suites)
+      - [TLSConnectionSettings.cipher_suites](#tlsconnectionsettingscipher_suites)
     + [ProxyConnectionSettings Message](#proxyconnectionsettings-message)
       - [ProxyConnectionSettings.url](#proxyconnectionsettingsurl)
       - [ProxyConnectionSettings.connect_headers](#proxyconnectionsettingsconnect_headers)
@@ -753,7 +753,7 @@ See [AvailableComponents](#availablecomponents-message) message for details.
 
 Status: [Development]
 
-The status of the connection settings that was previously recieved from the
+The status of the connection settings that was previously received from the
 Server. See [ConnectionSettingsStatus](#connectionsettingsstatus-message)
 message for details. This field SHOULD be unset if this information is unchanged
 since the last AgentToServer message. This field is a part of the
@@ -1351,7 +1351,7 @@ message ConnectionSettingsStatus {
         // Agent is currently applying the offered connection settings that it received earlier.
         APPLYING = 2;
 
-        // Agent tried to apply the offered connection settings recieved earlier, but it failed.
+        // Agent tried to apply the offered connection settings received earlier, but it failed.
         // See error_message for more details.
         FAILED = 3;
     }
@@ -1519,7 +1519,7 @@ An error message if the status is erroneous.
 
 Status: [Development]
 
-The download_details contains additional details that descibe a package download.
+The download_details contains additional details that describe a package download.
 It should only be set if the status is `DOWNLOADING`.
 
 ```protobuf
@@ -2252,7 +2252,7 @@ This sets the minimum supported TLS version the client will use. For example:
 This sets the maximum supported TLS version the client will use. For example:
 `1.2`, `TLSv1.2`.
 
-##### TLSConnectionSettings.ciper_suites
+##### TLSConnectionSettings.cipher_suites
 
 This sets the supported cipher suites that may be used by the connection. For
 example: `TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA`.


### PR DESCRIPTION
### Why

Proto file contains a typo that fails markdown checks in some repos (like opentelemetry-dotnet-contrib)
src: https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4374

### What

- Ports `crate-ci/typos` ci action from  opentelemetry-dotnet-contrib to opamp-spec.
- Fixes typos it found.