### PR TITLE
Fix max_version field comment in proto

### DIFF
--- a/proto/opamp.proto
+++ b/proto/opamp.proto
@@ -443,7 +443,7 @@ message TLSConnectionSettings {
   // Minimum accepted TLS version; default "1.2".
   string min_version = 4;
 
-  // Minimum accepted TLS version; default "".
+  // Maximum accepted TLS version; default "".
   string max_version = 5;
 
   // Explicit list of cipher suites.


### PR DESCRIPTION
### What

Fixes a wrong comment in proto.
Followup to #316

Spotted in https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/4374#discussion_r3232544204