### PR TITLE
Add role to AgentConfigFile

### DIFF
--- a/proto/opamp/v1/opamp.proto
+++ b/proto/opamp/v1/opamp.proto
@@ -1045,13 +1045,18 @@ message AgentConfigMap {
 }
 
 message AgentConfigFile {
-    // Config file or section body. The content, format and encoding depends on the Agent
-    // type. The content_type field may optionally describe the MIME type of the body.
+    // Config file, section, or supplementary content body. The content, format and
+    // encoding depends on the Agent type. The content_type field may optionally
+    // describe the MIME type of the body.
     bytes body = 1;
 
     // Optional MIME Content-Type that describes what's in the body field, for
     // example "text/yaml".
     string content_type = 2;
+
+    // Optional role of the content in the body field. The values and their semantics
+    // are Agent type-specific.
+    string role = 3;
 }
 
 /////////////////////////////////////////////////////////////////////////////////////

--- a/specification.md
+++ b/specification.md
@@ -2626,6 +2626,7 @@ following structure:
 message AgentConfigFile {
   bytes body = 1;
   string content_type = 2;
+  string role = 3;
 }
 ```
 
@@ -2638,6 +2639,11 @@ what's contained in the body field, for example "text/yaml". The content_type
 reported in the Effective Configuration in the Agent's status report may be used
 for example by the Server to visualize the reported configuration nicely in a
 UI.
+
+role is an optional field that describes the role of the content. The values and
+their semantics are Agent type-specific. For example, an Agent type may use this
+field to distinguish top-level configuration from supplementary content such as
+certificates or other artifacts referenced by configuration.
 
 #### Security Considerations
 


### PR DESCRIPTION
Adds optional `role` to `AgentConfigFile` so agent-specific implementations can distinguish top-level configuration from supplementary content.

Fixes #184