### PR TITLE
Restructure proto folders: move from proto to proto/opamp/v1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,18 +51,21 @@ markdownlint:
 
 GENDIR := gen
 # Find all .proto files.
-PROTO_FILES := $(wildcard proto/*.proto)
+PROTO_FILES := $(wildcard proto/opamp/v1/*.proto)
 
 PROTO_GEN_GO_DIR ?= $(GENDIR)/go
+PROTO_GEN_PYTHON_DIR ?= $(GENDIR)/python
+PROTO_GEN_CSHARP_DIR ?= $(GENDIR)/csharp
 
-OTEL_DOCKER_PROTOBUF ?= otel/build-protobuf:0.14.0
+# https://github.com/open-telemetry/build-tools/releases 
+OTEL_DOCKER_PROTOBUF ?= otel/build-protobuf:0.25.0
 
 # Docker pull image.
 .PHONY: docker-pull
 docker-pull:
 	docker pull $(OTEL_DOCKER_PROTOBUF)
 
-gen-proto: gen-go
+gen-proto: gen-go gen-python gen-csharp
 .PHONY: gen-proto
 
 # Generate Protobuf Go files.
@@ -72,6 +75,28 @@ gen-go:
 	mkdir -p ./$(PROTO_GEN_GO_DIR)
 
 	# Verify generation of Go protos
-	$(foreach file,$(PROTO_FILES),$(call exec-command,docker run --rm -v${PWD}:${PWD} \
+	$(foreach file,$(PROTO_FILES),$(call exec-command,docker run --rm -u $(shell id -u):$(shell id -g) -v${PWD}:${PWD} \
         -w${PWD} $(OTEL_DOCKER_PROTOBUF) --proto_path=${PWD}/proto/ \
         --go_out=./$(PROTO_GEN_GO_DIR) -I${PWD}/proto/ ${PWD}/$(file)))
+
+# Generate Protobuf Python files.
+.PHONY: gen-python
+gen-python:
+	rm -rf ./$(PROTO_GEN_PYTHON_DIR)
+	mkdir -p ./$(PROTO_GEN_PYTHON_DIR)
+
+	# Verify generation of Python protos
+	$(foreach file,$(PROTO_FILES),$(call exec-command,docker run --rm -u $(shell id -u):$(shell id -g) -v${PWD}:${PWD} \
+        -w${PWD} $(OTEL_DOCKER_PROTOBUF) --proto_path=${PWD}/proto/ \
+        --python_out=./$(PROTO_GEN_PYTHON_DIR) -I${PWD}/proto/ ${PWD}/$(file)))
+
+# Generate Protobuf C# files.
+.PHONY: gen-csharp
+gen-csharp:
+	rm -rf ./$(PROTO_GEN_CSHARP_DIR)
+	mkdir -p ./$(PROTO_GEN_CSHARP_DIR)
+
+	# Verify generation of C# protos
+	$(foreach file,$(PROTO_FILES),$(call exec-command,docker run --rm -u $(shell id -u):$(shell id -g) -v${PWD}:${PWD} \
+        -w${PWD} $(OTEL_DOCKER_PROTOBUF) --proto_path=${PWD}/proto/ \
+        --csharp_out=./$(PROTO_GEN_CSHARP_DIR) -I${PWD}/proto/ ${PWD}/$(file)))

--- a/Makefile
+++ b/Makefile
@@ -54,10 +54,9 @@ GENDIR := gen
 PROTO_FILES := $(wildcard proto/opamp/v1/*.proto)
 
 PROTO_GEN_GO_DIR ?= $(GENDIR)/go
-PROTO_GEN_PYTHON_DIR ?= $(GENDIR)/python
 PROTO_GEN_CSHARP_DIR ?= $(GENDIR)/csharp
 
-# https://github.com/open-telemetry/build-tools/releases 
+# https://github.com/open-telemetry/build-tools/releases
 OTEL_DOCKER_PROTOBUF ?= otel/build-protobuf:0.25.0
 
 # Docker pull image.
@@ -65,7 +64,7 @@ OTEL_DOCKER_PROTOBUF ?= otel/build-protobuf:0.25.0
 docker-pull:
 	docker pull $(OTEL_DOCKER_PROTOBUF)
 
-gen-proto: gen-go gen-python gen-csharp
+gen-proto: gen-go gen-csharp
 .PHONY: gen-proto
 
 # Generate Protobuf Go files.
@@ -78,17 +77,6 @@ gen-go:
 	$(foreach file,$(PROTO_FILES),$(call exec-command,docker run --rm -u $(shell id -u):$(shell id -g) -v${PWD}:${PWD} \
         -w${PWD} $(OTEL_DOCKER_PROTOBUF) --proto_path=${PWD}/proto/ \
         --go_out=./$(PROTO_GEN_GO_DIR) -I${PWD}/proto/ ${PWD}/$(file)))
-
-# Generate Protobuf Python files.
-.PHONY: gen-python
-gen-python:
-	rm -rf ./$(PROTO_GEN_PYTHON_DIR)
-	mkdir -p ./$(PROTO_GEN_PYTHON_DIR)
-
-	# Verify generation of Python protos
-	$(foreach file,$(PROTO_FILES),$(call exec-command,docker run --rm -u $(shell id -u):$(shell id -g) -v${PWD}:${PWD} \
-        -w${PWD} $(OTEL_DOCKER_PROTOBUF) --proto_path=${PWD}/proto/ \
-        --python_out=./$(PROTO_GEN_PYTHON_DIR) -I${PWD}/proto/ ${PWD}/$(file)))
 
 # Generate Protobuf C# files.
 .PHONY: gen-csharp

--- a/proto/opamp/v1/anyvalue.proto
+++ b/proto/opamp/v1/anyvalue.proto
@@ -20,10 +20,10 @@
 
 syntax = "proto3";
 
-package opamp.v1;
+package opamp.proto.v1;
 
 option go_package = "github.com/open-telemetry/opamp-go/protobufs";
-option csharp_namespace = "OpAmp.V1";
+option csharp_namespace = "OpAmp.Proto.V1";
 
 // AnyValue is used to represent any type of attribute value. AnyValue may contain a
 // primitive value such as a string or integer or it may contain an arbitrary nested

--- a/proto/opamp/v1/anyvalue.proto
+++ b/proto/opamp/v1/anyvalue.proto
@@ -20,10 +20,10 @@
 
 syntax = "proto3";
 
-package opamp.proto.v1;
+package opamp.v1;
 
 option go_package = "github.com/open-telemetry/opamp-go/protobufs";
-option csharp_namespace = "OpAmp.Proto.V1";
+option csharp_namespace = "OpAmp.V1";
 
 // AnyValue is used to represent any type of attribute value. AnyValue may contain a
 // primitive value such as a string or integer or it may contain an arbitrary nested

--- a/proto/opamp/v1/opamp.proto
+++ b/proto/opamp/v1/opamp.proto
@@ -16,12 +16,12 @@
 
 syntax = "proto3";
 
-package opamp.proto.v1;
+package opamp.v1;
 
-import "anyvalue.proto";
+import "opamp/v1/anyvalue.proto";
 
 option go_package = "github.com/open-telemetry/opamp-go/protobufs";
-option csharp_namespace = "OpAmp.Proto.V1";
+option csharp_namespace = "OpAmp.V1";
 
 message AgentToServer {
     // Globally unique identifier of the running instance of the Agent. SHOULD remain

--- a/proto/opamp/v1/opamp.proto
+++ b/proto/opamp/v1/opamp.proto
@@ -16,12 +16,12 @@
 
 syntax = "proto3";
 
-package opamp.v1;
+package opamp.proto.v1;
 
 import "opamp/v1/anyvalue.proto";
 
 option go_package = "github.com/open-telemetry/opamp-go/protobufs";
-option csharp_namespace = "OpAmp.V1";
+option csharp_namespace = "OpAmp.Proto.V1";
 
 message AgentToServer {
     // Globally unique identifier of the running instance of the Agent. SHOULD remain

--- a/specification.md
+++ b/specification.md
@@ -3692,8 +3692,8 @@ the new capabilities.
 
 #### Protobuf Schema Stability
 
-The specification provides the follow stability guarantees of the
-[Protobuf definitions](proto/opamp.proto) for OpAMP 1.0:
+The specification provides the following stability guarantees of the
+[Protobuf definitions](proto/opamp/v1/opamp.proto) for OpAMP 1.0:
 
 - Field types, numbers and names will not change.
 - Names of messages and enums will not change.


### PR DESCRIPTION
# Proto Restructuring
## Overview
This PR introduces changes to the proposed #338 proto folder structure.

## Changes

### 1. Proto Folder Restructuring
- **Move proto files** from `proto/` to `proto/opamp/v1/`
- **Update package name** from `opamp.proto.v1` to `opamp.v1`

**Outcome**: aligns with standard proto package naming conventions

### 2. Configuration Updates
- **Updated** `Makefile` to reflect new proto file paths, and generate Go, Python, and C# code
- **Updated** `specification.md` to reference the new proto structure

## Breaking Changes
- Python code is sensitive to the new package structure and needs to be updated
- C# namespace has changed to `Opamp.V1`