### PR TITLE
Recommend agent_disconnect for plain HTTP transport

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -3387,13 +3387,15 @@ frame and follow the procedure defined by WebSocket standard.
 #### Plain HTTP Transport
 
 Although the Client is logically disconnected as soon as the OpAMP HTTP response
-is completed, the Client SHOULD include the `agent_disconnect` field in the last
+is completed, the Client SHOULD include the
+[agent_disconnect](#agenttoserveragent_disconnect) field in the last
 AgentToServer message when the Client is shutting down or when the Client is about
 to use new OpAMP connection settings. This allows the Server to immediately mark
 the Agent as disconnected rather than waiting for missed polling intervals, which
 is especially useful for large reporting intervals.
 
-If the Client is unable to send `agent_disconnect` (e.g. due to an abrupt
+If the Client is unable to send
+[agent_disconnect](#agenttoserveragent_disconnect) (e.g. due to an abrupt
 termination), the Server may use its own business logic to decide what it considers
 an active Agent (e.g. a Client that continuously polls) vs an inactive Agent (e.g.
 a Client that has not made an HTTP request for a specific period of time). This

--- a/specification.md
+++ b/specification.md
@@ -3386,18 +3386,21 @@ frame and follow the procedure defined by WebSocket standard.
 
 #### Plain HTTP Transport
 
-The Client is considered logically disconnected as soon as the OpAMP HTTP
-response is completed. It is not necessary for the Client to send AgentToServer
-message with agent_disconnect field set since it is always implied anyway that
-the Client connection is gone after the HTTP response is completed.
+Although the Client is logically disconnected as soon as the OpAMP HTTP response
+is completed, the Client SHOULD include the `agent_disconnect` field in the last
+AgentToServer message when the Client is shutting down or when the Client is about
+to use new OpAMP connection settings. This allows the Server to immediately mark
+the Agent as disconnected rather than waiting for missed polling intervals, which
+is especially useful for large reporting intervals.
+
+If the Client is unable to send `agent_disconnect` (e.g. due to an abrupt
+termination), the Server may use its own business logic to decide what it considers
+an active Agent (e.g. a Client that continuously polls) vs an inactive Agent (e.g.
+a Client that has not made an HTTP request for a specific period of time). This
+business logic is outside the scope of OpAMP specification.
 
 HTTP keep-alive may be used by the Client and the Server but it has no effect on
 the logical operation of the OpAMP protocol.
-
-The Server may use its own business logic to decide what it considers an active
-Agent (e.g. an Client that continuously polls) vs an inactive Agent (e.g. a
-Client that has not made an HTTP request for a specific period of time). This business
-logic is outside the scope of OpAMP specification.
 
 ### Restoring WebSocket Connection
 


### PR DESCRIPTION
Update the Plain HTTP Transport section under "Closing Connection" to recommend (SHOULD) that HTTP clients include `agent_disconnect` in the last AgentToServer message on shutdown or when switching to new connection settings. This makes disconnect signalling consistent across WebSocket and plain HTTP transports.

The server-side cleanup heuristic is retained as a fallback for ungraceful terminations.

A corresponding implementation change will be needed in [opamp-go](https://github.com/open-telemetry/opamp-go).

Fixes #303
