### PR TITLE
Fix SDK service namespace identifying attribute

### DIFF
--- a/opentelemetry-guidelines.md
+++ b/opentelemetry-guidelines.md
@@ -48,7 +48,7 @@ Language instrumentation agents MUST copy the following OpenTelemetry SDK
 
 - `service.name`
 - `service.instance.id`
-- `service.namespace.name`, if present
+- `service.namespace`, if present
 
 These identifying attributes MUST match the values that the agent uses in the
 Resource of its own telemetry.


### PR DESCRIPTION
## Summary

- Change the SDK identifying attribute from `service.namespace.name` to `service.namespace`.

## Rationale

`service.namespace.name` is not an OpenTelemetry semantic convention attribute. The service resource conventions define `service.namespace`, and the service-instance identity is the `service.namespace`, `service.name`, and `service.instance.id` tuple. This also aligns the SDK guidance with the Collector guidance in this document.

The incorrect name was introduced in #312 while translating the service identity tuple into the SDK-specific OpAMP guidance.

## Validation

- `markdownlint`