### PR TITLE
Clarify configuration map semantics: rename "file" to "object", allow empty key unconditionally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.20.0
+
+* Rename `AgentConfigFile` to `AgentConfigObject` by @assafad1 in https://github.com/open-telemetry/opamp-spec/pull/385
+
 ## v0.19.0
 
 * Add transport message size limits by @pellared in https://github.com/open-telemetry/opamp-spec/pull/346

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.20.0
 
-* Rename `AgentConfigFile` to `AgentConfigObject` by @assafad1 in https://github.com/open-telemetry/opamp-spec/pull/385
+* **Breaking change**: Rename `AgentConfigFile` to `AgentConfigObject` by @assafad1 in https://github.com/open-telemetry/opamp-spec/pull/385
 
 ## v0.19.0
 

--- a/proto/opamp/v1/opamp.proto
+++ b/proto/opamp/v1/opamp.proto
@@ -1036,11 +1036,10 @@ message AgentRemoteConfig {
 }
 
 message AgentConfigMap {
-    // Map of configs. Keys are config file names or config section names.
-    // The configuration is assumed to be a collection of one or more named config files
-    // or sections.
-    // For agents that use a single config file or section the map SHOULD contain a single
-    // entry and the key may be an empty string.
+    // Map of configuration objects. Keys are agent-implementation-defined names
+    // for each object. An Agent type MAY assign special meaning to specific keys,
+    // including the empty string (""). For agents that use a single configuration
+    // object the map SHOULD contain a single entry and the key MAY be an empty string.
     map<string, AgentConfigFile> config_map = 1;
 }
 

--- a/proto/opamp/v1/opamp.proto
+++ b/proto/opamp/v1/opamp.proto
@@ -1040,10 +1040,10 @@ message AgentConfigMap {
     // for each object. An Agent type MAY assign special meaning to specific keys,
     // including the empty string (""). For agents that use a single configuration
     // object the map SHOULD contain a single entry and the key MAY be an empty string.
-    map<string, AgentConfigFile> config_map = 1;
+    map<string, AgentConfigObject> config_map = 1;
 }
 
-message AgentConfigFile {
+message AgentConfigObject {
     // Config file, section, or supplementary content body. The content, format and
     // encoding depends on the Agent type. The content_type field may optionally
     // describe the MIME type of the body.

--- a/proto/opamp/v1/opamp.proto
+++ b/proto/opamp/v1/opamp.proto
@@ -1038,8 +1038,9 @@ message AgentRemoteConfig {
 message AgentConfigMap {
     // Map of configuration objects. Keys are agent-implementation-defined names
     // for each object. An Agent type MAY assign special meaning to specific keys,
-    // including the empty string (""). For agents that use a single configuration
-    // object the map SHOULD contain a single entry and the key MAY be an empty string.
+    // including the empty string (""). The empty string is a valid key and MAY be
+    // used regardless of how many entries are in the map. For agents that use a
+    // single configuration object the map SHOULD contain a single entry.
     map<string, AgentConfigObject> config_map = 1;
 }
 

--- a/specification.md
+++ b/specification.md
@@ -2612,7 +2612,7 @@ message:
 
 ```protobuf
 message AgentConfigMap {
-  map<string, AgentConfigFile> config_map = 1;
+  map<string, AgentConfigObject> config_map = 1;
 }
 ```
 
@@ -2622,11 +2622,11 @@ agent-implementation-defined names for each configuration object.
 For Agents that use a single configuration object the config_map field SHOULD
 contain a single entry.
 
-The AgentConfigFile message represents one configuration object and has the
+The AgentConfigObject message represents one configuration object and has the
 following structure:
 
 ```protobuf
-message AgentConfigFile {
+message AgentConfigObject {
   bytes body = 1;
   string content_type = 2;
   string role = 3;

--- a/specification.md
+++ b/specification.md
@@ -154,7 +154,7 @@ Status: [Beta]
       - [TLSCertificate.ca_cert](#tlscertificateca_cert)
   * [Own Telemetry Reporting](#own-telemetry-reporting)
   * [Configuration](#configuration)
-    + [Configuration Files](#configuration-files)
+    + [Configuration Objects](#configuration-objects)
     + [Security Considerations](#security-considerations)
     + [AgentRemoteConfig Message](#agentremoteconfig-message)
   * [Packages](#packages)
@@ -2590,21 +2590,24 @@ Config │    Config │  ServerToAgent{AgentRemoteConfig} │   │and     │
 The Agent may ignore the Remote Configuration offer if it does not want its
 configuration to be remotely controlled by the Server.
 
-#### Configuration Files
+#### Configuration Objects
 
-The configuration of the Agent is a collection of named configuration files
+The configuration of the Agent is a collection of named configuration objects
 (this applies both to the Remote Configuration and to the Effective
 Configuration).
 
-The file names MUST be unique within the collection. It is possible that the
-Remote and Local Configuration MAY contain a file with the same name but with a
-different content. How these files are merged to form an Effective Configuration
-is Agent type-specific and is not part of the OpAMP protocol.
+Key names MUST be unique within the collection. Key names are
+agent-implementation-defined. An Agent type MAY assign special meaning to
+specific keys, including the empty string. It is possible that the Remote and
+Local Configuration MAY contain an object with the same key but with different
+content. How these objects are merged to form an Effective Configuration is Agent
+type-specific and is not part of the OpAMP protocol.
 
-If there is only one configuration file in the collection then the file name MAY
-be empty.
+The empty string ("") is a valid key and MAY be used. An object need not
+correspond to a distinct part of the configuration; an Agent type MAY use
+separate keys to expose alternative representations of the same configuration.
 
-The collection of configuration files is represented using a AgentConfigMap
+The collection of configuration objects is represented using an AgentConfigMap
 message:
 
 ```protobuf
@@ -2613,13 +2616,13 @@ message AgentConfigMap {
 }
 ```
 
-The config_map field of the AgentConfigSet message is a map of configuration
-files, where keys are file names.
+The config_map field of the AgentConfigMap message is a map where keys are
+agent-implementation-defined names for each configuration object.
 
-For Agents that use a single config file the config_map field SHOULD contain a
-single entry and the key MAY be an empty string.
+For Agents that use a single configuration object the config_map field SHOULD
+contain a single entry.
 
-The AgentConfigFile message represents one configuration file and has the
+The AgentConfigFile message represents one configuration object and has the
 following structure:
 
 ```protobuf
@@ -2630,8 +2633,8 @@ message AgentConfigFile {
 }
 ```
 
-The body field contains the raw bytes of the configuration file. The content,
-format and encoding of the raw bytes is Agent type-specific and is outside the
+The body field contains the bytes of the configuration object. The content,
+format and encoding of the body bytes is Agent type-specific and is outside the
 concerns of OpAMP protocol.
 
 content_type is an optional field. It is a MIME Content-Type that describes

--- a/specification.md
+++ b/specification.md
@@ -2634,8 +2634,8 @@ message AgentConfigObject {
 ```
 
 The body field contains the bytes of the configuration object. The content,
-format and encoding of the body bytes is Agent type-specific and is outside the
-concerns of OpAMP protocol.
+format and encoding of the body bytes are Agent type-specific and are outside the
+concerns of the OpAMP protocol.
 
 content_type is an optional field. It is a MIME Content-Type that describes
 what's contained in the body field, for example "text/yaml". The content_type


### PR DESCRIPTION
While reviewing open-telemetry/opentelemetry-collector-contrib#49692 (adding `reports_raw_config` to the OTel Collector), I noticed the spec's "Configuration Files" section has a couple of things that don't match how the protocol is actually used.

The empty-key restriction doesn't make sense. The spec says `""` is only allowed when there's a single entry in the map, but there's no good reason for that - it's just a convention. @tigrannajaryan confirmed it was unintentional.

"File" is also the wrong abstraction. The entries in `AgentConfigMap` aren't files, they're named blobs. The contrib PR is a good example: it uses `""` for the expanded config and a separate key for an alternative representation. Neither is a file.

What changed:
- Renamed `AgentConfigFile` to `AgentConfigObject` (suggested in SIG call)
- Renamed the section from "Configuration Files" to "Configuration Objects" and updated prose throughout
- Keys are now explicitly agent-implementation-defined; any key including `""` is valid
- Added a note that multiple keys can represent alternative views of the same configuration
- Dropped "raw" from the body field description
- Fixed a pre-existing typo: "AgentConfigSet" -> "AgentConfigMap"

Follows up on open-telemetry/opentelemetry-collector-contrib#49692 with @douglascamata, @jade-guiton-dd, and @tigrannajaryan.