### PR TITLE
Prepare release 0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.19.0
+
+* Add transport message size limits by @pellared in https://github.com/open-telemetry/opamp-spec/pull/346
+* Restructure proto folders: move from proto to proto/opamp/v1 by @juandemanjon in https://github.com/open-telemetry/opamp-spec/pull/352
+* Add ComponentHealth.attributes by @michel-laterman in https://github.com/open-telemetry/opamp-spec/pull/334
+* Recommend agent_disconnect for plain HTTP transport by @Krishnachaitanyakc in https://github.com/open-telemetry/opamp-spec/pull/353
+* Fix SDK service namespace identifying attribute by @cijothomas in https://github.com/open-telemetry/opamp-spec/pull/381
+* Add role to AgentConfigFile by @dmitryax in https://github.com/open-telemetry/opamp-spec/pull/350
+
 ## v0.18.0
 
 * Fix OpAMP port in example by @tigrannajaryan in https://github.com/open-telemetry/opamp-spec/pull/331


### PR DESCRIPTION
Release draft: https://github.com/open-telemetry/opamp-spec/releases/tag/untagged-adb7d84a6be3b1badc00