### PR TITLE
Fix broken gnupg.org detached-signature link

### DIFF
--- a/proto/opamp/v1/opamp.proto
+++ b/proto/opamp/v1/opamp.proto
@@ -623,7 +623,7 @@ message DownloadableFile {
 
     // Optional signature of the file content. Can be used by the Agent to verify the
     // authenticity of the downloaded file, for example can be the
-    // [detached GPG signature](https://www.gnupg.org/gph/en/manual/x135.html#AEN160).
+    // [detached GPG signature](https://www.gnupg.org/gph/en/manual.html#AEN161).
     // The exact signing and verification method is Agent specific. See
     // https://github.com/open-telemetry/opamp-spec/blob/main/specification.md#code-signing
     // for recommendations.

--- a/specification.md
+++ b/specification.md
@@ -2981,7 +2981,7 @@ was downloaded correctly.
 
 Optional signature of the file content. Can be used by the Agent to verify the
 authenticity of the downloaded file, for example can be the
-[detached GPG signature](https://www.gnupg.org/gph/en/manual/x135.html#AEN160).
+[detached GPG signature](https://www.gnupg.org/gph/en/manual.html#AEN161).
 The exact signing and verification method is Agent specific. See
 [Code Signing](#code-signing) for recommendations.
 
@@ -3638,7 +3638,7 @@ recommend the following:
 * The downloadable code can be signed with the signature included in the file content or
   have a detached signature recorded in the DownloadableFile
   message's [signature](#downloadablefilesignature) field. Detached signatures may be used
-  for example with [GPG signing](https://www.gnupg.org/gph/en/manual/x135.html#AEN160).
+  for example with [GPG signing](https://www.gnupg.org/gph/en/manual.html#AEN161).
 * If Certificate Authority is used for code signing it is recommended that the
   Certificate Authority and its private key is not co-located with the OpAMP
   Server, so that a compromised Server cannot sign malicious code.


### PR DESCRIPTION
The link checker on opentelemetry.io flagged this as dead: open-telemetry/opentelemetry.io#11364.

## What's in this PR

- Point the GPG detached-signature reference in `specification.md` and `proto/opamp/v1/opamp.proto` at `manual.html#AEN161`. The old chunked page (`manual/x135.html#AEN160`) no longer exists. gnupg.org's manual is now a single page, and the anchor renumbered

## Verification

- Confirmed `manual.html#AEN161` resolves and contains the same "Detached signatures" section (same `--detach-sig` example) as the old page

---

> Co-authored with Claude Opus 5.